### PR TITLE
feat(calc): add numba-accelerated DCAPE calculation

### DIFF
--- a/src/skyborn/calc/__init__.py
+++ b/src/skyborn/calc/__init__.py
@@ -12,6 +12,7 @@ This module contains various calculation functions including:
 """
 
 from .calculations import (
+    calculate_dcape,
     calculate_potential_temperature,
     convert_longitude_range,
     kendall_correlation,

--- a/src/skyborn/calc/calculations.py
+++ b/src/skyborn/calc/calculations.py
@@ -42,6 +42,7 @@ __all__ = [
     "spearman_correlation",
     "kendall_correlation",
     "calculate_potential_temperature",
+    "calculate_dcape",
 ]
 
 
@@ -588,5 +589,337 @@ def calculate_theta_se(
                 "long_name": "Pseudo-Equivalent Potential Temperature",
             },
         )
-
     return theta_se
+
+
+# =============================================================================
+# DCAPE calculation (Numba-accelerated)
+# =============================================================================
+
+try:
+    from numba import njit, prange
+
+    NUMBA_AVAILABLE = True
+except Exception:  # pragma: no cover
+    NUMBA_AVAILABLE = False
+
+    def njit(*args, **kwargs):  # type: ignore
+        def wrap(func):
+            return func
+
+        return wrap
+
+    def prange(*args):  # type: ignore
+        return range(*args)
+
+
+_EPS, _RD, _CP, _LV = 0.622, 287.05, 1004.0, 2.5e6
+_KAPPA = _RD / _CP
+
+
+@njit(cache=True)
+def _sat_vapor_pressure_hpa(tc):
+    return 6.112 * np.exp(17.67 * tc / (tc + 243.5))
+
+
+@njit(cache=True)
+def _sat_vapor_pressure_pa_from_tk(tk):
+    return _sat_vapor_pressure_hpa(tk - 273.15) * 100.0
+
+
+@njit(cache=True)
+def _mixing_ratio_from_e_pa(p_pa, e_pa):
+    e = max(e_pa, 1e-8)
+    e = min(e, 0.99 * p_pa)
+    return _EPS * e / (p_pa - e)
+
+
+@njit(cache=True)
+def _virtual_temp_k(tk, mixing_ratio):
+    return tk * (mixing_ratio + _EPS) / (_EPS * (1.0 + mixing_ratio))
+
+
+@njit(cache=True)
+def _thetae_bolton_like_metpy(p_hpa, tc, tdc):
+    t = tc + 273.15
+    td = max(tdc + 273.15, 173.15)
+
+    p_pa = p_hpa * 100.0
+    e_pa = _sat_vapor_pressure_hpa(tdc) * 100.0
+    r = _mixing_ratio_from_e_pa(p_pa, e_pa)
+
+    t_l = 56.0 + 1.0 / (1.0 / (td - 56.0) + np.log(t / td) / 800.0)
+    th_l = t * (100000.0 / (p_pa - e_pa)) ** _KAPPA * (t / t_l) ** (0.28 * r)
+    return th_l * np.exp(r * (1.0 + 0.448 * r) * (3036.0 / t_l - 1.78))
+
+
+@njit(cache=True)
+def _dt_dp_moist(p_pa, t_k):
+    es = _sat_vapor_pressure_pa_from_tk(t_k)
+    rs = _mixing_ratio_from_e_pa(p_pa, es)
+    num = _RD * t_k + _LV * rs
+    den = _CP + (_LV * _LV * rs * _EPS) / (_RD * t_k * t_k)
+    return (num / den) / p_pa
+
+
+@njit(cache=True)
+def _rk4_integrate_moist_t(p_start_pa, t_start_k, p_target_pa):
+    dp_total = p_target_pa - p_start_pa
+    if np.abs(dp_total) < 1e-9:
+        return t_start_k
+
+    nstep = int(np.abs(dp_total) / 200.0) + 1
+    h = dp_total / nstep
+    p, t = p_start_pa, t_start_k
+
+    for _ in range(nstep):
+        k1 = _dt_dp_moist(p, t)
+        k2 = _dt_dp_moist(p + 0.5 * h, t + 0.5 * h * k1)
+        k3 = _dt_dp_moist(p + 0.5 * h, t + 0.5 * h * k2)
+        k4 = _dt_dp_moist(p + h, t + h * k3)
+        t += (h / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4)
+        p += h
+    return t
+
+
+@njit(cache=True)
+def _lcl_bolton(p_hpa, tc, tdc):
+    t = tc + 273.15
+    td = max(tdc + 273.15, 173.15)
+    tlcl = 56.0 + 1.0 / (1.0 / (td - 56.0) + np.log(t / td) / 800.0)
+    plcl = p_hpa * (tlcl / t) ** (1.0 / _KAPPA)
+    return plcl, tlcl
+
+
+@njit(cache=True)
+def _interp_linear_p(p0, v0, p1, v1, p_target):
+    if np.abs(p1 - p0) < 1e-12:
+        return v0
+    if p0 > 0.0 and p1 > 0.0 and p_target > 0.0:
+        lp0, lp1, lpt = np.log(p0), np.log(p1), np.log(p_target)
+        if np.abs(lp1 - lp0) < 1e-12:
+            return v0
+        w = (lpt - lp0) / (lp1 - lp0)
+    else:
+        w = (p_target - p0) / (p1 - p0)
+    return v0 + w * (v1 - v0)
+
+
+@njit(cache=True)
+def _thetae_min_in_700_500(p, t, td, m):
+    min_te = 1.0e99
+    start_p = np.nan
+    start_t = np.nan
+    start_td = np.nan
+    found = False
+
+    for k in range(m):
+        pk = p[k]
+        if 500.0 <= pk <= 700.0:
+            te = _thetae_bolton_like_metpy(pk, t[k], td[k])
+            if te < min_te:
+                min_te, start_p, start_t, start_td, found = te, pk, t[k], td[k], True
+
+    for bound in (700.0, 500.0):
+        for k in range(m - 1):
+            p0, p1 = p[k], p[k + 1]
+            if (p0 >= bound >= p1) or (p0 <= bound <= p1):
+                tb = _interp_linear_p(p0, t[k], p1, t[k + 1], bound)
+                tdb = _interp_linear_p(p0, td[k], p1, td[k + 1], bound)
+                te = _thetae_bolton_like_metpy(bound, tb, tdb)
+                if te < min_te:
+                    min_te, start_p, start_t, start_td, found = te, bound, tb, tdb, True
+                break
+
+    return found, start_p, start_t, start_td
+
+
+@njit(cache=True)
+def _compute_dcape_profile_numba(pressure_hpa, temperature_c, dewpoint_c):
+    n = pressure_hpa.size
+    p = np.empty(n, dtype=np.float64)
+    t = np.empty(n, dtype=np.float64)
+    td = np.empty(n, dtype=np.float64)
+
+    m = 0
+    for k in range(n):
+        pk, tk, tdk = pressure_hpa[k], temperature_c[k], dewpoint_c[k]
+        if np.isfinite(pk) and np.isfinite(tk) and np.isfinite(tdk):
+            p[m], t[m], td[m] = pk, tk, tdk
+            m += 1
+    if m < 4:
+        return np.nan
+
+    if p[0] < p[m - 1]:
+        for k in range(m // 2):
+            k2 = m - 1 - k
+            tmp = p[k]
+            p[k] = p[k2]
+            p[k2] = tmp
+            tmp = t[k]
+            t[k] = t[k2]
+            t[k2] = tmp
+            tmp = td[k]
+            td[k] = td[k2]
+            td[k2] = tmp
+
+    found, start_p_hpa, start_t_c, start_td_c = _thetae_min_in_700_500(p, t, td, m)
+    if not found:
+        return np.nan
+
+    start_idx = -1
+    for k in range(m):
+        if p[k] >= start_p_hpa:
+            start_idx = k
+        else:
+            break
+    if start_idx <= 0:
+        return np.nan
+
+    plcl_hpa, tlcl_k = _lcl_bolton(start_p_hpa, start_t_c, start_td_c)
+    tw_start_k = _rk4_integrate_moist_t(plcl_hpa * 100.0, tlcl_k, start_p_hpa * 100.0)
+
+    parcel_tk = np.empty(start_idx + 1, dtype=np.float64)
+    parcel_tk[start_idx] = _rk4_integrate_moist_t(
+        start_p_hpa * 100.0, tw_start_k, p[start_idx] * 100.0
+    )
+    for k in range(start_idx, 0, -1):
+        parcel_tk[k - 1] = _rk4_integrate_moist_t(
+            p[k] * 100.0, parcel_tk[k], p[k - 1] * 100.0
+        )
+
+    integral = 0.0
+    prev_diff = 0.0
+    prev_lnp = 0.0
+    first = True
+
+    for k in range(start_idx + 1):
+        p_pa = p[k] * 100.0
+        e_env = _sat_vapor_pressure_hpa(td[k]) * 100.0
+        r_env = _mixing_ratio_from_e_pa(p_pa, e_env)
+        tv_env = _virtual_temp_k(t[k] + 273.15, r_env)
+
+        e_par = _sat_vapor_pressure_pa_from_tk(parcel_tk[k])
+        r_par = _mixing_ratio_from_e_pa(p_pa, e_par)
+        tv_par = _virtual_temp_k(parcel_tk[k], r_par)
+
+        diff = tv_env - tv_par
+        lnp = np.log(p[k])
+        if first:
+            prev_diff, prev_lnp, first = diff, lnp, False
+        else:
+            integral += 0.5 * (prev_diff + diff) * (lnp - prev_lnp)
+            prev_diff, prev_lnp = diff, lnp
+
+    dcape = -_RD * integral
+    if not np.isfinite(dcape):
+        return np.nan
+    return 0.0 if dcape < 0.0 else dcape
+
+
+@njit(cache=True, parallel=True)
+def _compute_dcape_grid_numba(pressure_3d, t_3d, td_3d, j_map, i_map):
+    nj, ni = j_map.size, i_map.size
+    out = np.empty((nj, ni), dtype=np.float32)
+
+    for sj in prange(nj):
+        j = j_map[sj]
+        for si in range(ni):
+            i = i_map[si]
+            out[sj, si] = _compute_dcape_profile_numba(
+                pressure_3d[:, j, i], t_3d[:, j, i], td_3d[:, j, i]
+            )
+
+    return out
+
+
+def calculate_dcape(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+) -> Union[np.ndarray, xr.DataArray, float]:
+    """
+    Calculate Downdraft Convective Available Potential Energy (DCAPE).
+
+    This implementation uses a Numba-accelerated Bolton-like moist-adiabatic
+    integration with RK4. It finds the minimum theta-e layer between 700 and
+    500 hPa, computes the wet-bulb temperature along a pseudoadiabat down to
+    the surface, and integrates the negative buoyancy.
+
+    Parameters
+    ----------
+    pressure : np.ndarray or xr.DataArray
+        Pressure in hPa. Can be 1D (level,) for a single profile, or 3D
+        (level, lat, lon) for a spatial grid.
+    temperature : np.ndarray or xr.DataArray
+        Temperature in Celsius. Same shape as ``pressure``.
+    dewpoint : np.ndarray or xr.DataArray
+        Dewpoint temperature in Celsius. Same shape as ``pressure``.
+
+    Returns
+    -------
+    np.ndarray or xr.DataArray or float
+        DCAPE in J kg^-1. For 3D input returns a 2D array (lat, lon).
+        For 1D input returns a scalar float.
+
+    Notes
+    -----
+    - If numba is not available the calculation still works but will be much
+      slower for grid data.
+    - Profiles with fewer than 4 valid levels, or without a detectable
+      theta-e minimum between 500--700 hPa, return NaN.
+    """
+    # Extract numpy arrays
+    p = getattr(pressure, "values", pressure)
+    t = getattr(temperature, "values", temperature)
+    td = getattr(dewpoint, "values", dewpoint)
+
+    is_xarray = hasattr(pressure, "attrs")
+
+    # 1D profile case
+    if p.ndim == 1:
+        result = _compute_dcape_profile_numba(
+            p.astype(np.float64),
+            t.astype(np.float64),
+            td.astype(np.float64),
+        )
+        return float(result)
+
+    # 3D grid case: (level, lat, lon)
+    if p.ndim == 3:
+        nz, ny, nx = p.shape
+        j_idx = np.arange(ny, dtype=np.int64)
+        i_idx = np.arange(nx, dtype=np.int64)
+
+        out = _compute_dcape_grid_numba(
+            p.astype(np.float64),
+            t.astype(np.float64),
+            td.astype(np.float64),
+            j_idx,
+            i_idx,
+        )
+
+        if is_xarray:
+            # Attempt to preserve spatial coordinates from the input
+            coords = {}
+            dims = []
+            if hasattr(pressure, "coords"):
+                coord_names = list(pressure.coords)
+                # Assume last two dims are the spatial ones
+                spatial_dims = pressure.dims[-2:]
+                for d in spatial_dims:
+                    if d in pressure.coords:
+                        coords[d] = pressure.coords[d]
+                dims = list(spatial_dims)
+            return xr.DataArray(
+                out,
+                dims=dims or ["y", "x"],
+                coords=coords,
+                attrs={"units": "J kg-1", "long_name": "DCAPE"},
+            )
+        return out
+
+    raise ValueError(
+        f"pressure must be 1D or 3D, got shape {p.shape}"
+    )
+


### PR DESCRIPTION
- Add calculate_dcape() to calculations.py with full numba acceleration
- Supports 1D profiles (scalar output) and 3D grids (2D output)
- Accepts both numpy arrays and xarray DataArray inputs
- Returns xr.DataArray with proper units/long_name when input is xarray
- Implements Bolton-like moist adiabatic integration with RK4
- Finds minimum theta-e layer between 700-500 hPa as downdraft source
- Graceful fallback to pure Python if numba is unavailable
- Export calculate_dcape in calc __init__.py and __all__