### PR TITLE
feat: add ventilation index module for tropical cyclone research

### DIFF
--- a/src/skyborn/calc/__init__.py
+++ b/src/skyborn/calc/__init__.py
@@ -27,6 +27,7 @@ _SUBMODULE_EXPORTS = {
     "growth_rate",
     "mann_kendall",
     "troposphere",
+    "ventilation",
 }
 
 _OBJECT_EXPORTS = {

--- a/src/skyborn/calc/__init__.py
+++ b/src/skyborn/calc/__init__.py
@@ -72,6 +72,19 @@ _OBJECT_EXPORTS = {
     "geostrophic_uv": ("skyborn.calc.geostrophic", "geostrophic_uv"),
     "geostrophic_wind": ("skyborn.calc.geostrophic", "geostrophic_wind"),
     "potential_intensity": ("skyborn.calc.GPI.core", "potential_intensity"),
+    # Tropical cyclone ventilation index (Chavas et al. 2025).
+    "absolute_vorticity_850": (
+        "skyborn.calc.ventilation",
+        "absolute_vorticity_850",
+    ),
+    "entropy_deficit": ("skyborn.calc.ventilation", "entropy_deficit"),
+    "genesis_potential_index": (
+        "skyborn.calc.ventilation",
+        "genesis_potential_index",
+    ),
+    "ventilated_pi": ("skyborn.calc.ventilation", "ventilated_pi"),
+    "ventilation_index": ("skyborn.calc.ventilation", "ventilation_index"),
+    "vertical_wind_shear": ("skyborn.calc.ventilation", "vertical_wind_shear"),
     "baroc_growth_rate": ("skyborn.calc.growth_rate", "baroc_growth_rate"),
     "barot_growth_rate": ("skyborn.calc.growth_rate", "barot_growth_rate"),
     "trop_wmo": ("skyborn.calc.troposphere", "trop_wmo"),

--- a/src/skyborn/calc/__init__.py
+++ b/src/skyborn/calc/__init__.py
@@ -77,10 +77,18 @@ _OBJECT_EXPORTS = {
         "skyborn.calc.ventilation",
         "absolute_vorticity_850",
     ),
+    "air_sea_disequilibrium": (
+        "skyborn.calc.ventilation",
+        "air_sea_disequilibrium",
+    ),
     "entropy_deficit": ("skyborn.calc.ventilation", "entropy_deficit"),
     "genesis_potential_index": (
         "skyborn.calc.ventilation",
         "genesis_potential_index",
+    ),
+    "ventilation_components": (
+        "skyborn.calc.ventilation",
+        "ventilation_components",
     ),
     "ventilated_pi": ("skyborn.calc.ventilation", "ventilated_pi"),
     "ventilation_index": ("skyborn.calc.ventilation", "ventilation_index"),

--- a/src/skyborn/calc/ventilation/__init__.py
+++ b/src/skyborn/calc/ventilation/__init__.py
@@ -28,6 +28,7 @@ Astrophys. J., 898, 115.
 """
 
 from .ventilation import (
+    VI_MAX,
     absolute_vorticity_850,
     entropy_deficit,
     genesis_potential_index,
@@ -39,6 +40,7 @@ from .ventilation import (
 __version__ = "1.0.0"
 
 __all__ = [
+    "VI_MAX",
     "absolute_vorticity_850",
     "entropy_deficit",
     "genesis_potential_index",

--- a/src/skyborn/calc/ventilation/__init__.py
+++ b/src/skyborn/calc/ventilation/__init__.py
@@ -7,11 +7,13 @@ Tippett (2025, J. Climate).
 The module provides:
 
 - Vertical wind shear (VWS) between 200 and 850 hPa
+- Air-sea entropy disequilibrium (from PI diagnostics)
 - Entropy deficit (Chi) at 600 hPa
 - Ventilation index (VI = VWS * Chi / PI)
 - Ventilated potential intensity (vPI) via analytic cubic solution
 - Clipped 850-hPa absolute vorticity (eta_c)
 - Ventilated genesis potential index (GPIv)
+- High-level pipeline ``ventilation_components`` combining all steps
 
 References
 ----------
@@ -30,8 +32,10 @@ Astrophys. J., 898, 115.
 from .ventilation import (
     VI_MAX,
     absolute_vorticity_850,
+    air_sea_disequilibrium,
     entropy_deficit,
     genesis_potential_index,
+    ventilation_components,
     ventilated_pi,
     ventilation_index,
     vertical_wind_shear,
@@ -42,8 +46,10 @@ __version__ = "1.0.0"
 __all__ = [
     "VI_MAX",
     "absolute_vorticity_850",
+    "air_sea_disequilibrium",
     "entropy_deficit",
     "genesis_potential_index",
+    "ventilation_components",
     "ventilated_pi",
     "ventilation_index",
     "vertical_wind_shear",

--- a/src/skyborn/calc/ventilation/__init__.py
+++ b/src/skyborn/calc/ventilation/__init__.py
@@ -1,0 +1,48 @@
+"""Skyborn Tropical Cyclone Ventilation Index Module.
+
+This module implements the ventilated potential intensity (vPI) framework
+and the associated genesis potential index (GPIv) from Chavas, Camargo &
+Tippett (2025, J. Climate).
+
+The module provides:
+
+- Vertical wind shear (VWS) between 200 and 850 hPa
+- Entropy deficit (Chi) at 600 hPa
+- Ventilation index (VI = VWS * Chi / PI)
+- Ventilated potential intensity (vPI) via analytic cubic solution
+- Clipped 850-hPa absolute vorticity (eta_c)
+- Ventilated genesis potential index (GPIv)
+
+References
+----------
+Chavas, D. R., S. J. Camargo, and M. K. Tippett, 2025: Tropical Cyclone
+Genesis Potential Using a Ventilated Potential Intensity. J. Climate, 38,
+1667–1689, https://doi.org/10.1175/JCLI-D-24-0186.1
+
+Tang, B., and K. Emanuel, 2012: A ventilation index for tropical cyclones.
+Bull. Amer. Meteor. Soc., 93, 1901–1912.
+
+Komacek, T. D., D. R. Chavas, and D. S. Abbot, 2020: Hurricane genesis is
+favorable on terrestrial exoplanets orbiting late-type M dwarf stars.
+Astrophys. J., 898, 115.
+"""
+
+from .ventilation import (
+    absolute_vorticity_850,
+    entropy_deficit,
+    genesis_potential_index,
+    ventilated_pi,
+    ventilation_index,
+    vertical_wind_shear,
+)
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "absolute_vorticity_850",
+    "entropy_deficit",
+    "genesis_potential_index",
+    "ventilated_pi",
+    "ventilation_index",
+    "vertical_wind_shear",
+]

--- a/src/skyborn/calc/ventilation/ventilation.py
+++ b/src/skyborn/calc/ventilation/ventilation.py
@@ -13,44 +13,157 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
-# Physical constants
-EARTH_RADIUS = 6_371_000.0  # m
-EARTH_OMEGA = 7.2921159e-5  # s^-1
 VI_MAX = 0.145  # Maximum ventilation index for nonzero vPI
 
+# Thermodynamic constants used by the Chavas et al. (2025) entropy deficit.
+DRY_AIR_CP = 1005.7  # J kg^-1 K^-1
+DRY_AIR_GAS_CONSTANT = 287.04  # J kg^-1 K^-1
+WATER_VAPOR_GAS_CONSTANT = 461.5  # J kg^-1 K^-1
+LATENT_HEAT_VAPORIZATION = 2.501e6  # J kg^-1
+TRIPLE_POINT_TEMPERATURE = 273.15  # K
+REFERENCE_PRESSURE = 100000.0  # Pa
+PRESSURE_600_HPA = 60000.0  # Pa
 
-def _drop_scalar_level(da: xr.DataArray) -> xr.DataArray:
-    """Remove scalar level coordinate left by ``.sel(level=...)``."""
-    if "level" in da.coords and "level" not in da.dims:
-        return da.drop_vars("level")
+
+def _drop_scalar_coord(da: xr.DataArray, coord_name: str) -> xr.DataArray:
+    """Remove scalar coordinate left by ``.sel(...)``."""
+    if coord_name in da.coords and coord_name not in da.dims:
+        return da.drop_vars(coord_name)
     return da
+
+
+def _get_metpy_calc():
+    """Lazy import of metpy.calc to avoid loading MetPy at module import time."""
+    import metpy.calc as mpcalc
+
+    return mpcalc
+
+
+def _with_default_units(da: xr.DataArray, units: str) -> xr.DataArray:
+    """Return a shallow copy with default units when metadata is missing."""
+    if "units" in da.attrs:
+        return da
+
+    da_with_units = da.copy(deep=False)
+    da_with_units.attrs = {**da.attrs, "units": units}
+    return da_with_units
+
+
+def _temperature_to_kelvin(da: xr.DataArray) -> xr.DataArray:
+    """Return temperature in Kelvin, assuming Kelvin when units are missing."""
+    units = str(da.attrs.get("units", "K")).strip().lower()
+    celsius_units = {"c", "°c", "degc", "degree_celsius", "degrees_celsius"}
+    if units in celsius_units or units in {"celsius", "degrees celsius"}:
+        out = da + 273.15
+        out.attrs = {**da.attrs, "units": "K"}
+        return out
+    return da
+
+
+def _mixing_ratio_from_specific_humidity(q: xr.DataArray) -> xr.DataArray:
+    """Convert specific humidity [kg/kg] to water-vapor mixing ratio [kg/kg]."""
+    return q / (1.0 - q)
+
+
+def _saturation_vapor_pressure(temperature: xr.DataArray) -> xr.DataArray:
+    """Calculate saturation vapor pressure over liquid water [Pa]."""
+    return 611.2 * np.exp(
+        17.67 * (temperature - TRIPLE_POINT_TEMPERATURE) / (temperature - 29.65)
+    )
+
+
+def _moist_entropy(
+    pressure: float,
+    temperature: xr.DataArray,
+    mixing_ratio: xr.DataArray,
+) -> xr.DataArray:
+    """Calculate moist entropy [J kg^-1 K^-1]."""
+    vapor_density_factor = DRY_AIR_GAS_CONSTANT + (
+        mixing_ratio * WATER_VAPOR_GAS_CONSTANT
+    )
+    moist_air_density = pressure / (temperature * vapor_density_factor)
+    vapor_pressure = mixing_ratio * moist_air_density * WATER_VAPOR_GAS_CONSTANT
+    vapor_pressure = vapor_pressure * temperature
+    saturation_pressure = _saturation_vapor_pressure(temperature)
+    relative_humidity = (vapor_pressure / saturation_pressure).clip(min=1e-10)
+    dry_air_pressure = pressure - vapor_pressure
+
+    return (
+        DRY_AIR_CP * np.log(temperature / TRIPLE_POINT_TEMPERATURE)
+        - DRY_AIR_GAS_CONSTANT * np.log(dry_air_pressure / REFERENCE_PRESSURE)
+        + LATENT_HEAT_VAPORIZATION * mixing_ratio / temperature
+        - WATER_VAPOR_GAS_CONSTANT * mixing_ratio * np.log(relative_humidity)
+    )
+
+
+def _saturation_entropy(
+    pressure: float,
+    temperature: xr.DataArray,
+) -> xr.DataArray:
+    """Calculate saturation moist entropy [J kg^-1 K^-1]."""
+    saturation_pressure = _saturation_vapor_pressure(temperature)
+    dry_air_pressure = pressure - saturation_pressure
+    saturation_mixing_ratio = (
+        DRY_AIR_GAS_CONSTANT
+        / WATER_VAPOR_GAS_CONSTANT
+        * saturation_pressure
+        / dry_air_pressure
+    )
+
+    return (
+        DRY_AIR_CP * np.log(temperature / TRIPLE_POINT_TEMPERATURE)
+        - DRY_AIR_GAS_CONSTANT * np.log(dry_air_pressure / REFERENCE_PRESSURE)
+        + LATENT_HEAT_VAPORIZATION * saturation_mixing_ratio / temperature
+    )
+
+
+def _ventilated_pi_ratio(vi_values: np.ndarray, vi_max: float) -> np.ndarray:
+    """Calculate vPI/PI from VI values."""
+    vi_values = np.asarray(vi_values, dtype=float)
+
+    # Normalized ventilation ratio.
+    r = vi_values / vi_max
+
+    # Solve the cubic y³ - y + 2r/(3√3) = 0 for y = vPI / PI
+    # using np.lib.scimath for type-safe complex intermediate values.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        term1 = np.lib.scimath.sqrt(r**2 - 1.0)
+        term2 = np.lib.scimath.power(term1 - r, 1.0 / 3.0)
+        x = (1.0 / np.sqrt(3.0)) * term2
+        ratio = np.real(x + 1.0 / (3.0 * x))
+
+    mask = np.isfinite(vi_values) & (vi_values > 0) & (vi_values <= vi_max)
+    return np.where(mask, ratio, np.nan).astype(float, copy=False)
 
 
 def vertical_wind_shear(
     ds: xr.Dataset,
     u_var: str = "U",
     v_var: str = "V",
+    level_coord: str = "level",
 ) -> xr.DataArray:
     """Calculate the 200–850 hPa vertical wind shear.
 
     Parameters
     ----------
     ds : xr.Dataset
-        Dataset containing wind components with a ``level`` dimension.
+        Dataset containing wind components with a pressure-level coordinate.
     u_var : str
         Name of the zonal wind variable (default ``"U"``).
     v_var : str
         Name of the meridional wind variable (default ``"V"``).
+    level_coord : str
+        Name of the pressure-level coordinate (default ``"level"``).
 
     Returns
     -------
     xr.DataArray
-        Wind shear magnitude in m/s with ``level`` dimension removed.
+        Wind shear magnitude in m/s with pressure-level dimension removed.
     """
-    u200 = _drop_scalar_level(ds[u_var].sel(level=200))
-    u850 = _drop_scalar_level(ds[u_var].sel(level=850))
-    v200 = _drop_scalar_level(ds[v_var].sel(level=200))
-    v850 = _drop_scalar_level(ds[v_var].sel(level=850))
+    u200 = _drop_scalar_coord(ds[u_var].sel({level_coord: 200}), level_coord)
+    u850 = _drop_scalar_coord(ds[u_var].sel({level_coord: 850}), level_coord)
+    v200 = _drop_scalar_coord(ds[v_var].sel({level_coord: 200}), level_coord)
+    v850 = _drop_scalar_coord(ds[v_var].sel({level_coord: 850}), level_coord)
 
     vws = np.hypot(u200 - u850, v200 - v850)
     vws.attrs = {
@@ -62,40 +175,51 @@ def vertical_wind_shear(
 
 def entropy_deficit(
     ds: xr.Dataset,
-    rh_var: str = "R",
+    air_sea_disequilibrium: xr.DataArray,
+    t_var: str = "T",
     q_var: str = "Q",
+    level_coord: str = "level",
 ) -> xr.DataArray:
     """Calculate the entropy deficit parameter (Chi) at 600 hPa.
 
-    Uses a robust relative-humidity-based proxy following the approach
-    in Chavas et al. (2025), Eq. (3).  When 600-hPa relative humidity
-    is available, the proxy is::
+    Follows Chavas et al. (2025), Eq. (3)::
 
-        χ = 1 − RH₆₀₀ / 100
+        χ = (s*_m(600) − s_m(600)) / (s*_SST − s_b)
 
-    Otherwise, a specific-humidity-based normalization is used.
+    where the numerator is computed from 600-hPa temperature and
+    specific humidity, and ``air_sea_disequilibrium`` supplies the
+    denominator from the potential-intensity calculation.
 
     Parameters
     ----------
     ds : xr.Dataset
-        Dataset with humidity variables on pressure levels.
-    rh_var : str
-        Name of the relative humidity variable (default ``"R"``).
+        Dataset with temperature and humidity variables on pressure levels.
+    air_sea_disequilibrium : xr.DataArray
+        Air-sea entropy disequilibrium term [J kg^-1 K^-1].
+    t_var : str
+        Name of the temperature variable in Kelvin (default ``"T"``).
     q_var : str
-        Name of the specific humidity variable (default ``"Q"``).
+        Name of the specific humidity variable in kg/kg (default ``"Q"``).
+    level_coord : str
+        Name of the pressure-level coordinate (default ``"level"``).
 
     Returns
     -------
     xr.DataArray
-        Dimensionless entropy deficit, clipped to [0.02, 1.5].
+        Dimensionless entropy deficit.
     """
-    if rh_var in ds:
-        chi = 1.0 - _drop_scalar_level(ds[rh_var].sel(level=600)) / 100.0
-    else:
-        q600 = _drop_scalar_level(ds[q_var].sel(level=600))
-        chi = 1.0 - q600 / q600.quantile(0.98)
+    t600 = _temperature_to_kelvin(
+        _drop_scalar_coord(ds[t_var].sel({level_coord: 600}), level_coord)
+    )
+    q600 = _drop_scalar_coord(ds[q_var].sel({level_coord: 600}), level_coord)
+    mixing_ratio_600 = _mixing_ratio_from_specific_humidity(q600)
 
-    chi = chi.clip(min=0.02, max=1.5)
+    moist_entropy_600 = _moist_entropy(PRESSURE_600_HPA, t600, mixing_ratio_600)
+    saturation_entropy_600 = _saturation_entropy(PRESSURE_600_HPA, t600)
+    chi = (saturation_entropy_600 - moist_entropy_600) / air_sea_disequilibrium
+
+    chi = chi.where(np.isfinite(chi) & (chi > 0))
+    chi = chi.clip(max=10.0)
     chi.attrs = {"long_name": "Entropy Deficit (Chi)", "units": "1"}
     return chi
 
@@ -129,6 +253,45 @@ def ventilation_index(
     return vi
 
 
+def air_sea_disequilibrium(
+    pi: xr.DataArray,
+    sst: xr.DataArray,
+    outflow_temperature: xr.DataArray,
+    ckcd: float = 0.9,
+) -> xr.DataArray:
+    """Calculate the air-sea entropy disequilibrium term used by ``Chi``.
+
+    This inverts the Emanuel PI relationship using the PI diagnostics already
+    produced by :mod:`skyborn.calc.GPI.xarray`.
+
+    Parameters
+    ----------
+    pi : xr.DataArray
+        Potential intensity [m/s].
+    sst : xr.DataArray
+        Sea-surface temperature [K] or [degC] if a units attribute is present.
+    outflow_temperature : xr.DataArray
+        Outflow temperature [K] or [degC] if a units attribute is present.
+    ckcd : float
+        Exchange coefficient ratio (default 0.9).
+
+    Returns
+    -------
+    xr.DataArray
+        Air-sea entropy disequilibrium [J kg^-1 K^-1].
+    """
+    sst_k = _temperature_to_kelvin(sst)
+    outflow_temperature_k = _temperature_to_kelvin(outflow_temperature)
+    asdeq = pi**2 * (1.0 / ckcd) * outflow_temperature_k
+    asdeq = asdeq / (sst_k * (sst_k - outflow_temperature_k))
+    asdeq = asdeq.where(np.isfinite(asdeq) & (asdeq > 0))
+    asdeq.attrs = {
+        "long_name": "Air-Sea Entropy Disequilibrium",
+        "units": "J kg^-1 K^-1",
+    }
+    return asdeq
+
+
 def ventilated_pi(
     pi: xr.DataArray,
     vi: xr.DataArray,
@@ -160,34 +323,140 @@ def ventilated_pi(
     xr.DataArray
         Ventilated potential intensity [m/s].
     """
-    vi_vals = np.asarray(vi.values, dtype=float)
-
-    # Normalized ventilation ratio
-    r = vi_vals / vi_max
-
-    # Solve the cubic y³ - y + 2r/(3√3) = 0  for  y = vPI / PI
-    # using np.lib.scimath for type-safe complex intermediate values.
-    with np.errstate(invalid="ignore"):
-        term1 = np.lib.scimath.sqrt(r**2 - 1.0)
-        term2 = np.lib.scimath.power(term1 - r, 1.0 / 3.0)
-        x = (1.0 / np.sqrt(3.0)) * term2
-        ratio = np.real(x + 1.0 / (3.0 * x))
-
-    # Mask invalid VI values
-    mask = np.isfinite(vi_vals) & (vi_vals > 0) & (vi_vals <= vi_max)
-    ratio = np.where(mask, ratio, np.nan)
-
-    ratio_da = xr.DataArray(ratio, coords=vi.coords, dims=vi.dims)
+    ratio_da = xr.apply_ufunc(
+        _ventilated_pi_ratio,
+        vi,
+        kwargs={"vi_max": vi_max},
+        dask="parallelized",
+        output_dtypes=[float],
+        keep_attrs=False,
+    )
     vpi = pi * ratio_da
     vpi = vpi.where(np.isfinite(vpi) & (vpi > 0))
     vpi.attrs = {"long_name": "Ventilated Potential Intensity", "units": "m/s"}
     return vpi
 
 
+def ventilation_components(
+    ds: xr.Dataset,
+    sst_var: str = "SSTK",
+    psl_var: str = "SP",
+    t_var: str = "T",
+    q_var: str = "Q",
+    u_var: str = "U",
+    v_var: str = "V",
+    level_coord: str = "level",
+    lat_coord: str = "latitude",
+    lon_coord: str = "longitude",
+    ckcd: float = 0.9,
+    vi_max: float = VI_MAX,
+    vorticity_cap: float = 3.7e-5,
+    dx: float = 2.0,
+    dy: float = 2.0,
+) -> xr.Dataset:
+    """Calculate PI, ventilation metrics, and GPIv from one dataset.
+
+    This high-level pipeline reuses the existing Skyborn GPI xarray backend for
+    potential intensity diagnostics, then applies the ventilation framework.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset containing SST, surface pressure, temperature, humidity, and
+        wind components.
+    sst_var, psl_var, t_var, q_var, u_var, v_var : str
+        Variable names in ``ds``.
+    level_coord : str
+        Name of the pressure-level coordinate.
+    lat_coord : str
+        Name of the latitude coordinate (default ``"latitude"``).
+    lon_coord : str
+        Name of the longitude coordinate (default ``"longitude"``).
+    ckcd : float
+        Exchange coefficient ratio passed to the GPI diagnostics.
+    vi_max : float
+        Maximum VI for nonzero vPI.
+    vorticity_cap : float
+        Upper bound for capped 850-hPa absolute vorticity.
+    dx, dy : float
+        Grid spacing in degrees for the final GPIv area factor.
+
+    Returns
+    -------
+    xr.Dataset
+        Dataset with PI diagnostics and ventilation components.
+    """
+    from skyborn.calc.GPI.xarray import pi_log_decomposition
+
+    mixing_ratio = _mixing_ratio_from_specific_humidity(ds[q_var])
+    mixing_ratio.attrs = {**ds[q_var].attrs, "units": "kg/kg"}
+
+    pi_diagnostics = pi_log_decomposition(
+        ds[sst_var],
+        ds[psl_var],
+        ds[level_coord],
+        ds[t_var],
+        mixing_ratio,
+        CKCD=ckcd,
+    )
+
+    pi = pi_diagnostics["pi"]
+    asdeq = air_sea_disequilibrium(pi, ds[sst_var], pi_diagnostics["t0"], ckcd=ckcd)
+    vws = vertical_wind_shear(
+        ds,
+        u_var=u_var,
+        v_var=v_var,
+        level_coord=level_coord,
+    )
+    chi = entropy_deficit(
+        ds,
+        asdeq,
+        t_var=t_var,
+        q_var=q_var,
+        level_coord=level_coord,
+    )
+    vi = ventilation_index(vws, chi, pi)
+    vpi = ventilated_pi(pi, vi, vi_max=vi_max)
+    eta_c = absolute_vorticity_850(
+        ds,
+        u_var=u_var,
+        v_var=v_var,
+        level_coord=level_coord,
+        lat_coord=lat_coord,
+        lon_coord=lon_coord,
+        cap=vorticity_cap,
+    )
+    gpi_v = genesis_potential_index(vpi, eta_c, dx=dx, dy=dy, lat_coord=lat_coord)
+
+    result = xr.Dataset(
+        data_vars={
+            "PI": pi,
+            "vPI": vpi,
+            "VWS": vws,
+            "Chi": chi,
+            "ventilation_index": vi,
+            "eta_c": eta_c,
+            "GPIv": gpi_v,
+            "air_sea_disequilibrium": asdeq,
+            "min_pressure": pi_diagnostics["min_pressure"],
+            "error_flag": pi_diagnostics["error_flag"],
+            "t0": pi_diagnostics["t0"],
+        },
+        attrs={
+            "title": "Ventilated Genesis Potential Index Components",
+            "method": "Chavas et al. (2025) ventilated PI/GPIv",
+        },
+    )
+    return result
+
+
 def absolute_vorticity_850(
     ds: xr.Dataset,
     u_var: str = "U",
     v_var: str = "V",
+    level_coord: str = "level",
+    lat_coord: str = "latitude",
+    lon_coord: str = "longitude",
     cap: float = 3.7e-5,
 ) -> xr.DataArray:
     """Calculate the clipped 850-hPa absolute vorticity.
@@ -195,15 +464,17 @@ def absolute_vorticity_850(
     Following Chavas et al. (2025), Eq. (7):
 
     .. math::
-       \\eta_c = \\begin{cases}
-         \\min(\\text{cap},\\, f + \\zeta_{850}) & \\text{if } f + \\zeta_{850} > 0 \\\\
-         \\text{NaN} & \\text{otherwise}
+       \\eta_c =
+       \\begin{cases}
+         \\text{cap} & \\text{if } |f + \\zeta_{850}| > \\text{cap} \\\\
+         f + \\zeta_{850} & \\text{otherwise}
        \\end{cases}
 
     where *f* is the Coriolis parameter, ζ₈₅₀ is the 850-hPa relative
-    vorticity (approximate — the metric term *u tan(φ)/r* is omitted),
-    and cap = 3.7 × 10⁻⁵ s⁻¹.  Negative absolute vorticity values are
-    masked out (NaN), consistent with the reference implementation.
+    vorticity, and ``f + ζ₈₅₀`` is calculated with MetPy on the
+    latitude-longitude grid.  Large-magnitude values are set to the positive
+    cap, and non-positive values are masked out (NaN), matching the
+    reference implementation used for Chavas et al. (2025).
 
     Parameters
     ----------
@@ -211,33 +482,48 @@ def absolute_vorticity_850(
         Dataset with wind components on pressure levels.
     u_var, v_var : str
         Variable names for zonal and meridional wind.
+    level_coord : str
+        Name of the pressure-level coordinate (default ``"level"``).
+    lat_coord : str
+        Name of the latitude coordinate (default ``"latitude"``).
+    lon_coord : str
+        Name of the longitude coordinate (default ``"longitude"``).
     cap : float
         Upper bound on absolute vorticity (default 3.7e-5 s^-1).
 
     Returns
     -------
     xr.DataArray
-        Clipped absolute vorticity [s^-1].
+        Clipped absolute vorticity [s^-1], NaN where non-positive.
     """
-    u = _drop_scalar_level(ds[u_var].sel(level=850))
-    v = _drop_scalar_level(ds[v_var].sel(level=850))
+    u = _drop_scalar_coord(ds[u_var].sel({level_coord: 850}), level_coord)
+    v = _drop_scalar_coord(ds[v_var].sel({level_coord: 850}), level_coord)
 
-    lat_rad = np.deg2rad(ds["latitude"])
+    mpcalc = _get_metpy_calc()
+    u_for_vorticity = _with_default_units(u, "m/s").metpy.quantify()
+    v_for_vorticity = _with_default_units(v, "m/s").metpy.quantify()
+    eta = mpcalc.absolute_vorticity(
+        u_for_vorticity,
+        v_for_vorticity,
+        latitude=ds[lat_coord],
+        longitude=ds[lon_coord],
+        x_dim=u.get_axis_num(lon_coord),
+        y_dim=u.get_axis_num(lat_coord),
+    ).metpy.dequantify()
+    eta = eta.rename("absolute_vorticity")
+    if "metpy_crs" in eta.coords:
+        eta = eta.drop_vars("metpy_crs")
 
-    # Relative vorticity on the sphere
-    dvdx = v.differentiate("longitude") / (
-        np.deg2rad(1.0) * EARTH_RADIUS * np.cos(lat_rad)
+    eta = eta.assign_coords(
+        {
+            coord: u.coords[coord]
+            for coord in u.coords
+            if coord in eta.coords and coord != "metpy_crs"
+        }
     )
-    dudy = u.differentiate("latitude") / (np.deg2rad(1.0) * EARTH_RADIUS)
-    rel_vort = dvdx - dudy
 
-    # Coriolis parameter
-    coriolis = 2.0 * EARTH_OMEGA * np.sin(lat_rad)
-
-    eta = rel_vort + coriolis
-
-    # Clip: set |eta| > cap to sign(eta) * cap
-    eta_c = xr.where(np.abs(eta) > cap, np.sign(eta) * cap, eta)
+    # Clip: set large-magnitude absolute vorticity to the positive cap.
+    eta_c = xr.where(np.abs(eta) > cap, cap, eta)
     eta_c = eta_c.where(eta_c > 0)  # Remove non-positive values
 
     eta_c.attrs = {
@@ -252,6 +538,7 @@ def genesis_potential_index(
     eta_c: xr.DataArray,
     dx: float = 2.0,
     dy: float = 2.0,
+    lat_coord: str = "latitude",
 ) -> xr.DataArray:
     """Calculate the ventilated genesis potential index (GPIv).
 
@@ -269,13 +556,15 @@ def genesis_potential_index(
         Clipped absolute vorticity [s^-1].
     dx, dy : float
         Grid spacing in degrees (default 2.0, matching the paper).
+    lat_coord : str
+        Name of the latitude coordinate (default ``"latitude"``).
 
     Returns
     -------
     xr.DataArray
         Ventilated genesis potential index.
     """
-    cos_lat = np.cos(np.deg2rad(vpi["latitude"]))
+    cos_lat = np.cos(np.deg2rad(vpi[lat_coord]))
     gpi_v = (102.1 * vpi * eta_c) ** 4.90 * cos_lat * dx * dy
     gpi_v = gpi_v.where(np.isfinite(gpi_v) & (gpi_v > 0))
     gpi_v.attrs = {

--- a/src/skyborn/calc/ventilation/ventilation.py
+++ b/src/skyborn/calc/ventilation/ventilation.py
@@ -140,9 +140,11 @@ def ventilated_pi(
     Cardano formula, matching Eqs. (5)-(6) of Chavas et al. (2025) and
     the reference implementation in tcvpigpiv v0.3.x.
 
-    At VI = 0, vPI = PI (no reduction).
-    At VI = VI_max, vPI = PI / sqrt(3) ≈ 0.5774 * PI.
-    For VI > VI_max, vPI = 0 (genesis impossible).
+    Boundary behaviour:
+
+    - VI → 0⁺:  vPI → PI  (no reduction)
+    - VI = VI_max:  vPI = PI / √3 ≈ 0.5774 × PI
+    - VI ≤ 0 or VI > VI_max:  vPI = NaN  (genesis impossible)
 
     Parameters
     ----------
@@ -158,19 +160,25 @@ def ventilated_pi(
     xr.DataArray
         Ventilated potential intensity [m/s].
     """
-    vi_limited = vi.where(vi <= vi_max)
+    vi_vals = np.asarray(vi.values, dtype=float)
 
-    def _ratio(v):
-        if not np.isfinite(v) or v <= 0 or v > vi_max:
-            return np.nan
-        ratio = v / vi_max
-        term1 = (ratio**2 - 1.0) ** 0.5
-        term2 = (term1 - ratio) ** (1.0 / 3.0)
+    # Normalized ventilation ratio
+    r = vi_vals / vi_max
+
+    # Solve the cubic y³ - y + 2r/(3√3) = 0  for  y = vPI / PI
+    # using np.lib.scimath for type-safe complex intermediate values.
+    with np.errstate(invalid="ignore"):
+        term1 = np.lib.scimath.sqrt(r**2 - 1.0)
+        term2 = np.lib.scimath.power(term1 - r, 1.0 / 3.0)
         x = (1.0 / np.sqrt(3.0)) * term2
-        return float(np.real(x + 1.0 / (3.0 * x)))
+        ratio = np.real(x + 1.0 / (3.0 * x))
 
-    ratio = xr.apply_ufunc(_ratio, vi_limited, vectorize=True, output_dtypes=[float])
-    vpi = pi * ratio
+    # Mask invalid VI values
+    mask = np.isfinite(vi_vals) & (vi_vals > 0) & (vi_vals <= vi_max)
+    ratio = np.where(mask, ratio, np.nan)
+
+    ratio_da = xr.DataArray(ratio, coords=vi.coords, dims=vi.dims)
+    vpi = pi * ratio_da
     vpi = vpi.where(np.isfinite(vpi) & (vpi > 0))
     vpi.attrs = {"long_name": "Ventilated Potential Intensity", "units": "m/s"}
     return vpi
@@ -187,11 +195,15 @@ def absolute_vorticity_850(
     Following Chavas et al. (2025), Eq. (7):
 
     .. math::
-       \\eta_c = \\min(3.7 \\times 10^{-5}, |f + \\zeta_{850}|)
+       \\eta_c = \\begin{cases}
+         \\min(\\text{cap},\\, f + \\zeta_{850}) & \\text{if } f + \\zeta_{850} > 0 \\\\
+         \\text{NaN} & \\text{otherwise}
+       \\end{cases}
 
-    where f is the Coriolis parameter and zeta_850 is the 850-hPa
-    relative vorticity.  Values are clipped to ±cap and only positive
-    values are retained.
+    where *f* is the Coriolis parameter, ζ₈₅₀ is the 850-hPa relative
+    vorticity (approximate — the metric term *u tan(φ)/r* is omitted),
+    and cap = 3.7 × 10⁻⁵ s⁻¹.  Negative absolute vorticity values are
+    masked out (NaN), consistent with the reference implementation.
 
     Parameters
     ----------

--- a/src/skyborn/calc/ventilation/ventilation.py
+++ b/src/skyborn/calc/ventilation/ventilation.py
@@ -1,0 +1,273 @@
+"""Ventilation index calculations for tropical cyclone research.
+
+Implements the ventilated potential intensity (vPI) framework and the
+ventilated genesis potential index (GPIv) following Chavas, Camargo &
+Tippett (2025).
+
+All functions accept and return ``xarray.DataArray`` objects for seamless
+integration with gridded climate datasets (ERA5, CMIP6, etc.).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+# Physical constants
+EARTH_RADIUS = 6_371_000.0  # m
+EARTH_OMEGA = 7.2921159e-5  # s^-1
+VI_MAX = 0.145  # Maximum ventilation index for nonzero vPI
+
+
+def _drop_scalar_level(da: xr.DataArray) -> xr.DataArray:
+    """Remove scalar level coordinate left by ``.sel(level=...)``."""
+    if "level" in da.coords and "level" not in da.dims:
+        return da.drop_vars("level")
+    return da
+
+
+def vertical_wind_shear(
+    ds: xr.Dataset,
+    u_var: str = "U",
+    v_var: str = "V",
+) -> xr.DataArray:
+    """Calculate the 200–850 hPa vertical wind shear.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset containing wind components with a ``level`` dimension.
+    u_var : str
+        Name of the zonal wind variable (default ``"U"``).
+    v_var : str
+        Name of the meridional wind variable (default ``"V"``).
+
+    Returns
+    -------
+    xr.DataArray
+        Wind shear magnitude in m/s with ``level`` dimension removed.
+    """
+    u200 = _drop_scalar_level(ds[u_var].sel(level=200))
+    u850 = _drop_scalar_level(ds[u_var].sel(level=850))
+    v200 = _drop_scalar_level(ds[v_var].sel(level=200))
+    v850 = _drop_scalar_level(ds[v_var].sel(level=850))
+
+    vws = np.hypot(u200 - u850, v200 - v850)
+    vws.attrs = {
+        "long_name": "Vertical Wind Shear (200-850 hPa)",
+        "units": "m/s",
+    }
+    return vws
+
+
+def entropy_deficit(
+    ds: xr.Dataset,
+    rh_var: str = "R",
+    q_var: str = "Q",
+) -> xr.DataArray:
+    """Calculate the entropy deficit parameter (Chi) at 600 hPa.
+
+    Uses a robust relative-humidity-based proxy following the approach
+    in Chavas et al. (2025), Eq. (3).  When 600-hPa relative humidity
+    is available, the proxy is::
+
+        χ = 1 − RH₆₀₀ / 100
+
+    Otherwise, a specific-humidity-based normalization is used.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset with humidity variables on pressure levels.
+    rh_var : str
+        Name of the relative humidity variable (default ``"R"``).
+    q_var : str
+        Name of the specific humidity variable (default ``"Q"``).
+
+    Returns
+    -------
+    xr.DataArray
+        Dimensionless entropy deficit, clipped to [0.02, 1.5].
+    """
+    if rh_var in ds:
+        chi = 1.0 - _drop_scalar_level(ds[rh_var].sel(level=600)) / 100.0
+    else:
+        q600 = _drop_scalar_level(ds[q_var].sel(level=600))
+        chi = 1.0 - q600 / q600.quantile(0.98)
+
+    chi = chi.clip(min=0.02, max=1.5)
+    chi.attrs = {"long_name": "Entropy Deficit (Chi)", "units": "1"}
+    return chi
+
+
+def ventilation_index(
+    vws: xr.DataArray,
+    chi: xr.DataArray,
+    pi: xr.DataArray,
+) -> xr.DataArray:
+    """Calculate the ventilation index (VI).
+
+    VI = VWS * Chi / PI  (Tang & Emanuel 2012, Eq. (2))
+
+    Parameters
+    ----------
+    vws : xr.DataArray
+        Vertical wind shear [m/s].
+    chi : xr.DataArray
+        Entropy deficit [dimensionless].
+    pi : xr.DataArray
+        Potential intensity [m/s].
+
+    Returns
+    -------
+    xr.DataArray
+        Ventilation index (dimensionless), NaN where <= 0.
+    """
+    vi = vws * chi / pi
+    vi = vi.where(np.isfinite(vi) & (vi > 0))
+    vi.attrs = {"long_name": "Ventilation Index", "units": "1"}
+    return vi
+
+
+def ventilated_pi(
+    pi: xr.DataArray,
+    vi: xr.DataArray,
+    vi_max: float = VI_MAX,
+) -> xr.DataArray:
+    """Calculate the ventilated potential intensity (vPI).
+
+    Solves the cubic equation for normalized vPI using the analytic
+    Cardano formula, matching Eqs. (5)-(6) of Chavas et al. (2025) and
+    the reference implementation in tcvpigpiv v0.3.x.
+
+    At VI = 0, vPI = PI (no reduction).
+    At VI = VI_max, vPI = PI / sqrt(3) ≈ 0.5774 * PI.
+    For VI > VI_max, vPI = 0 (genesis impossible).
+
+    Parameters
+    ----------
+    pi : xr.DataArray
+        Potential intensity [m/s].
+    vi : xr.DataArray
+        Ventilation index [dimensionless].
+    vi_max : float
+        Maximum VI for nonzero vPI (default 0.145).
+
+    Returns
+    -------
+    xr.DataArray
+        Ventilated potential intensity [m/s].
+    """
+    vi_limited = vi.where(vi <= vi_max)
+
+    def _ratio(v):
+        if not np.isfinite(v) or v <= 0 or v > vi_max:
+            return np.nan
+        ratio = v / vi_max
+        term1 = (ratio**2 - 1.0) ** 0.5
+        term2 = (term1 - ratio) ** (1.0 / 3.0)
+        x = (1.0 / np.sqrt(3.0)) * term2
+        return float(np.real(x + 1.0 / (3.0 * x)))
+
+    ratio = xr.apply_ufunc(_ratio, vi_limited, vectorize=True, output_dtypes=[float])
+    vpi = pi * ratio
+    vpi = vpi.where(np.isfinite(vpi) & (vpi > 0))
+    vpi.attrs = {"long_name": "Ventilated Potential Intensity", "units": "m/s"}
+    return vpi
+
+
+def absolute_vorticity_850(
+    ds: xr.Dataset,
+    u_var: str = "U",
+    v_var: str = "V",
+    cap: float = 3.7e-5,
+) -> xr.DataArray:
+    """Calculate the clipped 850-hPa absolute vorticity.
+
+    Following Chavas et al. (2025), Eq. (7):
+
+    .. math::
+       \\eta_c = \\min(3.7 \\times 10^{-5}, |f + \\zeta_{850}|)
+
+    where f is the Coriolis parameter and zeta_850 is the 850-hPa
+    relative vorticity.  Values are clipped to ±cap and only positive
+    values are retained.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset with wind components on pressure levels.
+    u_var, v_var : str
+        Variable names for zonal and meridional wind.
+    cap : float
+        Upper bound on absolute vorticity (default 3.7e-5 s^-1).
+
+    Returns
+    -------
+    xr.DataArray
+        Clipped absolute vorticity [s^-1].
+    """
+    u = _drop_scalar_level(ds[u_var].sel(level=850))
+    v = _drop_scalar_level(ds[v_var].sel(level=850))
+
+    lat_rad = np.deg2rad(ds["latitude"])
+
+    # Relative vorticity on the sphere
+    dvdx = v.differentiate("longitude") / (
+        np.deg2rad(1.0) * EARTH_RADIUS * np.cos(lat_rad)
+    )
+    dudy = u.differentiate("latitude") / (np.deg2rad(1.0) * EARTH_RADIUS)
+    rel_vort = dvdx - dudy
+
+    # Coriolis parameter
+    coriolis = 2.0 * EARTH_OMEGA * np.sin(lat_rad)
+
+    eta = rel_vort + coriolis
+
+    # Clip: set |eta| > cap to sign(eta) * cap
+    eta_c = xr.where(np.abs(eta) > cap, np.sign(eta) * cap, eta)
+    eta_c = eta_c.where(eta_c > 0)  # Remove non-positive values
+
+    eta_c.attrs = {
+        "long_name": "Capped 850-hPa Absolute Vorticity",
+        "units": "s^-1",
+    }
+    return eta_c
+
+
+def genesis_potential_index(
+    vpi: xr.DataArray,
+    eta_c: xr.DataArray,
+    dx: float = 2.0,
+    dy: float = 2.0,
+) -> xr.DataArray:
+    """Calculate the ventilated genesis potential index (GPIv).
+
+    Following Chavas et al. (2025), Eq. (8):
+
+    .. math::
+       \\mathrm{GPI}_v = (102.1 \\times \\mathrm{vPI} \\times \\eta_c)^{4.90}
+       \\times \\cos\\varphi \\times \\Delta x \\times \\Delta y
+
+    Parameters
+    ----------
+    vpi : xr.DataArray
+        Ventilated potential intensity [m/s].
+    eta_c : xr.DataArray
+        Clipped absolute vorticity [s^-1].
+    dx, dy : float
+        Grid spacing in degrees (default 2.0, matching the paper).
+
+    Returns
+    -------
+    xr.DataArray
+        Ventilated genesis potential index.
+    """
+    cos_lat = np.cos(np.deg2rad(vpi["latitude"]))
+    gpi_v = (102.1 * vpi * eta_c) ** 4.90 * cos_lat * dx * dy
+    gpi_v = gpi_v.where(np.isfinite(gpi_v) & (gpi_v > 0))
+    gpi_v.attrs = {
+        "long_name": "Ventilated Genesis Potential Index",
+        "units": "arbitrary",
+    }
+    return gpi_v

--- a/src/skyborn/calc/ventilation/ventilation.py
+++ b/src/skyborn/calc/ventilation/ventilation.py
@@ -62,14 +62,18 @@ def _temperature_to_kelvin(da: xr.DataArray) -> xr.DataArray:
 
 def _mixing_ratio_from_specific_humidity(q: xr.DataArray) -> xr.DataArray:
     """Convert specific humidity [kg/kg] to water-vapor mixing ratio [kg/kg]."""
-    return q / (1.0 - q)
+    mpcalc = _get_metpy_calc()
+    w = mpcalc.mixing_ratio_from_specific_humidity(q)
+    if hasattr(w, "metpy"):
+        w = w.metpy.dequantify()
+    return w
 
 
 def _saturation_vapor_pressure(temperature: xr.DataArray) -> xr.DataArray:
     """Calculate saturation vapor pressure over liquid water [Pa]."""
-    return 611.2 * np.exp(
-        17.67 * (temperature - TRIPLE_POINT_TEMPERATURE) / (temperature - 29.65)
-    )
+    mpcalc = _get_metpy_calc()
+    t = _with_default_units(temperature, "K").metpy.quantify()
+    return mpcalc.saturation_vapor_pressure(t).metpy.dequantify()
 
 
 def _moist_entropy(
@@ -78,12 +82,14 @@ def _moist_entropy(
     mixing_ratio: xr.DataArray,
 ) -> xr.DataArray:
     """Calculate moist entropy [J kg^-1 K^-1]."""
-    vapor_density_factor = DRY_AIR_GAS_CONSTANT + (
-        mixing_ratio * WATER_VAPOR_GAS_CONSTANT
-    )
-    moist_air_density = pressure / (temperature * vapor_density_factor)
-    vapor_pressure = mixing_ratio * moist_air_density * WATER_VAPOR_GAS_CONSTANT
-    vapor_pressure = vapor_pressure * temperature
+    mpcalc = _get_metpy_calc()
+    from metpy.units import units
+
+    p = pressure * units.Pa
+    t = _with_default_units(temperature, "K").metpy.quantify()
+    w = _with_default_units(mixing_ratio, "kg/kg").metpy.quantify()
+
+    vapor_pressure = mpcalc.vapor_pressure(p, w).metpy.dequantify()
     saturation_pressure = _saturation_vapor_pressure(temperature)
     relative_humidity = (vapor_pressure / saturation_pressure).clip(min=1e-10)
     dry_air_pressure = pressure - vapor_pressure
@@ -101,14 +107,15 @@ def _saturation_entropy(
     temperature: xr.DataArray,
 ) -> xr.DataArray:
     """Calculate saturation moist entropy [J kg^-1 K^-1]."""
+    mpcalc = _get_metpy_calc()
+    from metpy.units import units
+
+    p = pressure * units.Pa
+    t = _with_default_units(temperature, "K").metpy.quantify()
+
     saturation_pressure = _saturation_vapor_pressure(temperature)
+    saturation_mixing_ratio = mpcalc.saturation_mixing_ratio(p, t).metpy.dequantify()
     dry_air_pressure = pressure - saturation_pressure
-    saturation_mixing_ratio = (
-        DRY_AIR_GAS_CONSTANT
-        / WATER_VAPOR_GAS_CONSTANT
-        * saturation_pressure
-        / dry_air_pressure
-    )
 
     return (
         DRY_AIR_CP * np.log(temperature / TRIPLE_POINT_TEMPERATURE)

--- a/tests/test_calc_ventilation.py
+++ b/tests/test_calc_ventilation.py
@@ -234,8 +234,8 @@ class TestEntropyDeficit:
             },
         )
         chi = entropy_deficit(ds, asdeq)
-        expected = np.array([[0.73283812, 0.86396779], [1.09802141, 1.44103677]])
-        np.testing.assert_allclose(chi.values, expected, rtol=1e-7)
+        expected = np.array([[0.732269, 0.863263], [1.096719, 1.438259]])
+        np.testing.assert_allclose(chi.values, expected, rtol=1e-5)
 
     def test_custom_level_coord(
         self, sample_atmospheric_dataset, sample_air_sea_disequilibrium

--- a/tests/test_calc_ventilation.py
+++ b/tests/test_calc_ventilation.py
@@ -1,0 +1,523 @@
+"""Tests for skyborn.calc.ventilation module.
+
+Tests the ventilated potential intensity (vPI) framework and the
+ventilated genesis potential index (GPIv) following Chavas et al. (2025).
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from skyborn.calc.ventilation import (
+    absolute_vorticity_850,
+    entropy_deficit,
+    genesis_potential_index,
+    ventilated_pi,
+    ventilation_index,
+    vertical_wind_shear,
+)
+from skyborn.calc.ventilation.ventilation import VI_MAX
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_atmospheric_dataset():
+    """Create a small synthetic ERA5-like dataset for testing."""
+    np.random.seed(42)
+
+    levels = [200, 600, 850, 1000]
+    lats = np.arange(10, 41, 2.5)
+    lons = np.arange(100, 181, 2.5)
+    times = np.arange(4)
+
+    shape = (len(times), len(levels), len(lats), len(lons))
+
+    # Realistic-ish temperature profile (K) — reshape for broadcasting
+    T_base = np.array([220, 275, 285, 290]).reshape(1, -1, 1, 1)
+    T = np.broadcast_to(T_base, shape).astype(float).copy()
+    T += np.random.randn(*shape) * 2.0
+
+    # Specific humidity (kg/kg)
+    Q_base = np.array([1e-5, 0.003, 0.008, 0.012]).reshape(1, -1, 1, 1)
+    Q = np.broadcast_to(Q_base, shape).astype(float).copy()
+    Q += np.random.randn(*shape) * 0.0005
+
+    # Relative humidity (%)
+    R_base = np.array([10, 40, 60, 80]).reshape(1, -1, 1, 1)
+    R = np.broadcast_to(R_base, shape).astype(float).copy()
+    R += np.random.randn(*shape) * 3.0
+
+    # Zonal wind (m/s)
+    U_base = np.array([5, 2, -5, -3]).reshape(1, -1, 1, 1)
+    U = np.broadcast_to(U_base, shape).astype(float).copy()
+    U += np.random.randn(*shape) * 1.0
+
+    # Meridional wind (m/s)
+    V_base = np.array([2, 1, -2, -1]).reshape(1, -1, 1, 1)
+    V = np.broadcast_to(V_base, shape).astype(float).copy()
+    V += np.random.randn(*shape) * 1.0
+
+    ds = xr.Dataset(
+        data_vars={
+            "T": (["time", "level", "latitude", "longitude"], T),
+            "Q": (["time", "level", "latitude", "longitude"], Q),
+            "R": (["time", "level", "latitude", "longitude"], R),
+            "U": (["time", "level", "latitude", "longitude"], U),
+            "V": (["time", "level", "latitude", "longitude"], V),
+        },
+        coords={
+            "time": times,
+            "level": levels,
+            "latitude": lats,
+            "longitude": lons,
+        },
+    )
+    return ds
+
+
+@pytest.fixture
+def sample_pi_field(sample_atmospheric_dataset):
+    """Create a synthetic PI field matching the dataset grid."""
+    ds = sample_atmospheric_dataset
+    shape = (ds.sizes["time"], ds.sizes["latitude"], ds.sizes["longitude"])
+    pi = xr.DataArray(
+        np.random.uniform(40, 80, shape),
+        dims=["time", "latitude", "longitude"],
+        coords={
+            "time": ds.time,
+            "latitude": ds.latitude,
+            "longitude": ds.longitude,
+        },
+        attrs={"units": "m/s", "long_name": "Potential Intensity"},
+    )
+    return pi
+
+
+# ---------------------------------------------------------------------------
+# vertical_wind_shear
+# ---------------------------------------------------------------------------
+
+
+class TestVerticalWindShear:
+    """Tests for vertical_wind_shear."""
+
+    def test_returns_dataarray(self, sample_atmospheric_dataset):
+        vws = vertical_wind_shear(sample_atmospheric_dataset)
+        assert isinstance(vws, xr.DataArray)
+
+    def test_shape_no_level_dim(self, sample_atmospheric_dataset):
+        ds = sample_atmospheric_dataset
+        vws = vertical_wind_shear(ds)
+        assert "level" not in vws.dims
+        assert vws.sizes["time"] == ds.sizes["time"]
+        assert vws.sizes["latitude"] == ds.sizes["latitude"]
+        assert vws.sizes["longitude"] == ds.sizes["longitude"]
+
+    def test_values_nonnegative(self, sample_atmospheric_dataset):
+        vws = vertical_wind_shear(sample_atmospheric_dataset)
+        valid = vws.values[~np.isnan(vws.values)]
+        assert np.all(valid >= 0)
+
+    def test_attrs_set(self, sample_atmospheric_dataset):
+        vws = vertical_wind_shear(sample_atmospheric_dataset)
+        assert "units" in vws.attrs
+        assert vws.attrs["units"] == "m/s"
+
+    def test_known_values(self):
+        """Test with known wind values."""
+        ds = xr.Dataset(
+            data_vars={
+                "U": (
+                    ["level", "latitude", "longitude"],
+                    np.array([[[10, 10], [10, 10]], [[5, 5], [5, 5]]]),
+                ),
+                "V": (
+                    ["level", "latitude", "longitude"],
+                    np.array([[[0, 0], [0, 0]], [[0, 0], [0, 0]]]),
+                ),
+            },
+            coords={
+                "level": [200, 850],
+                "latitude": [0, 10],
+                "longitude": [0, 10],
+            },
+        )
+        vws = vertical_wind_shear(ds)
+        expected = np.full((2, 2), 5.0)
+        np.testing.assert_array_almost_equal(vws.values, expected)
+
+
+# ---------------------------------------------------------------------------
+# entropy_deficit
+# ---------------------------------------------------------------------------
+
+
+class TestEntropyDeficit:
+    """Tests for entropy_deficit."""
+
+    def test_returns_dataarray(self, sample_atmospheric_dataset):
+        chi = entropy_deficit(sample_atmospheric_dataset)
+        assert isinstance(chi, xr.DataArray)
+
+    def test_shape_no_level_dim(self, sample_atmospheric_dataset):
+        ds = sample_atmospheric_dataset
+        chi = entropy_deficit(ds)
+        assert "level" not in chi.dims
+
+    def test_values_in_range(self, sample_atmospheric_dataset):
+        chi = entropy_deficit(sample_atmospheric_dataset)
+        valid = chi.values[~np.isnan(chi.values)]
+        assert np.all(valid >= 0.02)
+        assert np.all(valid <= 1.5)
+
+    def test_rh_based_calculation(self):
+        """Test that chi = 1 - RH/100 when R is available."""
+        ds = xr.Dataset(
+            data_vars={
+                "R": (
+                    ["level", "latitude", "longitude"],
+                    np.array([[[50, 60], [70, 80]]]),
+                ),
+            },
+            coords={
+                "level": [600],
+                "latitude": [0, 10],
+                "longitude": [0, 10],
+            },
+        )
+        chi = entropy_deficit(ds)
+        expected = np.array([[0.5, 0.4], [0.3, 0.2]])
+        np.testing.assert_array_almost_equal(chi.values, expected)
+
+    def test_q_fallback(self):
+        """Test specific humidity fallback when R is not available."""
+        ds = xr.Dataset(
+            data_vars={
+                "Q": (
+                    ["level", "latitude", "longitude"],
+                    np.array([[[0.005, 0.010], [0.015, 0.020]]]),
+                ),
+            },
+            coords={
+                "level": [600],
+                "latitude": [0, 10],
+                "longitude": [0, 10],
+            },
+        )
+        chi = entropy_deficit(ds, rh_var="R_missing")
+        valid = chi.values[~np.isnan(chi.values)]
+        assert np.all(valid >= 0.02)
+        assert np.all(valid <= 1.5)
+
+
+# ---------------------------------------------------------------------------
+# ventilation_index
+# ---------------------------------------------------------------------------
+
+
+class TestVentilationIndex:
+    """Tests for ventilation_index."""
+
+    def test_returns_dataarray(self, sample_atmospheric_dataset, sample_pi_field):
+        ds = sample_atmospheric_dataset
+        vws = vertical_wind_shear(ds)
+        chi = entropy_deficit(ds)
+        vi = ventilation_index(vws, chi, sample_pi_field)
+        assert isinstance(vi, xr.DataArray)
+
+    def test_formula(self):
+        """Test VI = VWS * Chi / PI with known values."""
+        vws = xr.DataArray(np.array([10.0, 20.0]), dims=["x"])
+        chi = xr.DataArray(np.array([0.5, 0.3]), dims=["x"])
+        pi = xr.DataArray(np.array([50.0, 80.0]), dims=["x"])
+        vi = ventilation_index(vws, chi, pi)
+        expected = np.array([0.1, 0.075])
+        np.testing.assert_array_almost_equal(vi.values, expected)
+
+    def test_negative_vi_is_nan(self):
+        """VI should be NaN where the formula gives non-positive values."""
+        vws = xr.DataArray(np.array([0.0, -1.0]), dims=["x"])
+        chi = xr.DataArray(np.array([0.5, 0.3]), dims=["x"])
+        pi = xr.DataArray(np.array([50.0, 80.0]), dims=["x"])
+        vi = ventilation_index(vws, chi, pi)
+        assert np.isnan(vi.values[0])
+        assert np.isnan(vi.values[1])
+
+
+# ---------------------------------------------------------------------------
+# ventilated_pi
+# ---------------------------------------------------------------------------
+
+
+class TestVentilatedPI:
+    """Tests for ventilated_pi — the critical analytic cubic solution."""
+
+    def test_returns_dataarray(self):
+        pi = xr.DataArray(np.array([70.0, 80.0]), dims=["x"])
+        vi = xr.DataArray(np.array([0.05, 0.10]), dims=["x"])
+        vpi = ventilated_pi(pi, vi)
+        assert isinstance(vpi, xr.DataArray)
+
+    def test_vi_near_zero_vpi_equals_pi(self):
+        """At VI → 0, vPI should approach PI (ratio → 1)."""
+        pi = xr.DataArray(np.array([70.0]), dims=["x"])
+        vi = xr.DataArray(np.array([0.001]), dims=["x"])
+        vpi = ventilated_pi(pi, vi)
+        assert abs(vpi.values[0] - 70.0) < 1.0  # Within 1 m/s
+
+    def test_vi_at_vimax_ratio_is_1_over_sqrt3(self):
+        """At VI = VI_MAX, ratio should be 1/sqrt(3) ≈ 0.5774."""
+        pi_val = 70.0
+        pi = xr.DataArray(np.array([pi_val]), dims=["x"])
+        vi = xr.DataArray(np.array([VI_MAX]), dims=["x"])
+        vpi = ventilated_pi(pi, vi)
+        expected_ratio = 1.0 / np.sqrt(3.0)
+        np.testing.assert_almost_equal(vpi.values[0], pi_val * expected_ratio, decimal=3)
+
+    def test_vi_above_vimax_is_nan(self):
+        """VI > VI_MAX should produce NaN."""
+        pi = xr.DataArray(np.array([70.0]), dims=["x"])
+        vi = xr.DataArray(np.array([0.146]), dims=["x"])
+        vpi = ventilated_pi(pi, vi)
+        assert np.isnan(vpi.values[0])
+
+    def test_vi_negative_is_nan(self):
+        """Negative VI should produce NaN."""
+        pi = xr.DataArray(np.array([70.0]), dims=["x"])
+        vi = xr.DataArray(np.array([-0.05]), dims=["x"])
+        vpi = ventilated_pi(pi, vi)
+        assert np.isnan(vpi.values[0])
+
+    def test_vi_nan_is_nan(self):
+        """NaN VI should produce NaN."""
+        pi = xr.DataArray(np.array([70.0]), dims=["x"])
+        vi = xr.DataArray(np.array([np.nan]), dims=["x"])
+        vpi = ventilated_pi(pi, vi)
+        assert np.isnan(vpi.values[0])
+
+    def test_monotonic_decrease(self):
+        """vPI should decrease monotonically as VI increases."""
+        pi_val = 80.0
+        vi_values = np.linspace(0.01, VI_MAX, 20)
+        pi = xr.DataArray(np.full(20, pi_val), dims=["x"])
+        vi = xr.DataArray(vi_values, dims=["x"])
+        vpi = ventilated_pi(pi, vi)
+        diffs = np.diff(vpi.values)
+        assert np.all(diffs < 0), "vPI should decrease as VI increases"
+
+    def test_attrs_preserved(self):
+        pi = xr.DataArray(np.array([70.0]), dims=["x"])
+        vi = xr.DataArray(np.array([0.05]), dims=["x"])
+        vpi = ventilated_pi(pi, vi)
+        assert "units" in vpi.attrs
+        assert vpi.attrs["units"] == "m/s"
+
+    def test_custom_vi_max(self):
+        """Test with a custom vi_max parameter."""
+        pi = xr.DataArray(np.array([70.0]), dims=["x"])
+        vi = xr.DataArray(np.array([0.20]), dims=["x"])
+        # With default vi_max=0.145, VI=0.20 > 0.145 → NaN
+        vpi_default = ventilated_pi(pi, vi)
+        assert np.isnan(vpi_default.values[0])
+        # With vi_max=0.25, VI=0.20 is valid
+        vpi_custom = ventilated_pi(pi, vi, vi_max=0.25)
+        assert np.isfinite(vpi_custom.values[0])
+        assert vpi_custom.values[0] < 70.0  # Should be reduced
+
+
+# ---------------------------------------------------------------------------
+# absolute_vorticity_850
+# ---------------------------------------------------------------------------
+
+
+class TestAbsoluteVorticity850:
+    """Tests for absolute_vorticity_850."""
+
+    def test_returns_dataarray(self, sample_atmospheric_dataset):
+        eta_c = absolute_vorticity_850(sample_atmospheric_dataset)
+        assert isinstance(eta_c, xr.DataArray)
+
+    def test_shape_no_level_dim(self, sample_atmospheric_dataset):
+        ds = sample_atmospheric_dataset
+        eta_c = absolute_vorticity_850(ds)
+        assert "level" not in eta_c.dims
+
+    def test_values_capped(self, sample_atmospheric_dataset):
+        """All non-NaN values should be <= cap."""
+        eta_c = absolute_vorticity_850(sample_atmospheric_dataset)
+        valid = eta_c.values[~np.isnan(eta_c.values)]
+        assert np.all(np.abs(valid) <= 3.7e-5 + 1e-15)
+
+    def test_values_positive(self, sample_atmospheric_dataset):
+        """All non-NaN values should be positive."""
+        eta_c = absolute_vorticity_850(sample_atmospheric_dataset)
+        valid = eta_c.values[~np.isnan(eta_c.values)]
+        assert np.all(valid > 0)
+
+    def test_attrs_set(self, sample_atmospheric_dataset):
+        eta_c = absolute_vorticity_850(sample_atmospheric_dataset)
+        assert "units" in eta_c.attrs
+        assert eta_c.attrs["units"] == "s^-1"
+
+    def test_custom_cap(self, sample_atmospheric_dataset):
+        """Test with a custom cap value."""
+        eta_c = absolute_vorticity_850(sample_atmospheric_dataset, cap=5.0e-5)
+        valid = eta_c.values[~np.isnan(eta_c.values)]
+        assert np.all(np.abs(valid) <= 5.0e-5 + 1e-15)
+
+    def test_coriolis_at_equator(self):
+        """At the equator, Coriolis should be ~0."""
+        ds = xr.Dataset(
+            data_vars={
+                "U": (
+                    ["level", "latitude", "longitude"],
+                    np.zeros((1, 3, 3)),
+                ),
+                "V": (
+                    ["level", "latitude", "longitude"],
+                    np.zeros((1, 3, 3)),
+                ),
+            },
+            coords={
+                "level": [850],
+                "latitude": [0.0, 5.0, 10.0],
+                "longitude": [0.0, 5.0, 10.0],
+            },
+        )
+        eta_c = absolute_vorticity_850(ds)
+        # At equator (latitude=0), Coriolis=0 and vorticity≈0 → should be NaN (filtered)
+        assert np.isnan(eta_c.sel(latitude=0.0).values).all() or np.all(
+            eta_c.sel(latitude=0.0).values >= 0
+        )
+
+
+# ---------------------------------------------------------------------------
+# genesis_potential_index
+# ---------------------------------------------------------------------------
+
+
+class TestGenesisPotentialIndex:
+    """Tests for genesis_potential_index."""
+
+    def test_returns_dataarray(self):
+        vpi = xr.DataArray(
+            np.array([[50.0, 60.0], [40.0, 45.0]]),
+            dims=["latitude", "longitude"],
+            coords={"latitude": [10.0, 20.0], "longitude": [100.0, 110.0]},
+        )
+        eta_c = xr.DataArray(
+            np.array([[3e-5, 2e-5], [1e-5, 3.7e-5]]),
+            dims=["latitude", "longitude"],
+            coords={"latitude": [10.0, 20.0], "longitude": [100.0, 110.0]},
+        )
+        gpi_v = genesis_potential_index(vpi, eta_c)
+        assert isinstance(gpi_v, xr.DataArray)
+
+    def test_values_positive(self):
+        vpi = xr.DataArray(
+            np.array([[50.0, 60.0]]),
+            dims=["latitude", "longitude"],
+            coords={"latitude": [10.0], "longitude": [100.0, 110.0]},
+        )
+        eta_c = xr.DataArray(
+            np.array([[3e-5, 2e-5]]),
+            dims=["latitude", "longitude"],
+            coords={"latitude": [10.0], "longitude": [100.0, 110.0]},
+        )
+        gpi_v = genesis_potential_index(vpi, eta_c)
+        valid = gpi_v.values[~np.isnan(gpi_v.values)]
+        assert np.all(valid > 0)
+
+    def test_custom_grid_spacing(self):
+        """Test with custom dx/dy."""
+        vpi = xr.DataArray(
+            np.array([[50.0]]),
+            dims=["latitude", "longitude"],
+            coords={"latitude": [15.0], "longitude": [120.0]},
+        )
+        eta_c = xr.DataArray(
+            np.array([[3e-5]]),
+            dims=["latitude", "longitude"],
+            coords={"latitude": [15.0], "longitude": [120.0]},
+        )
+        gpi_default = genesis_potential_index(vpi, eta_c)
+        gpi_custom = genesis_potential_index(vpi, eta_c, dx=1.0, dy=1.0)
+        # Custom dx/dy=1 should be 1/4 of default (2*2)
+        ratio = gpi_custom.values[0] / gpi_default.values[0]
+        np.testing.assert_almost_equal(ratio, 0.25, decimal=5)
+
+    def test_attrs_set(self):
+        vpi = xr.DataArray(
+            np.array([[50.0]]),
+            dims=["latitude", "longitude"],
+            coords={"latitude": [15.0], "longitude": [120.0]},
+        )
+        eta_c = xr.DataArray(
+            np.array([[3e-5]]),
+            dims=["latitude", "longitude"],
+            coords={"latitude": [15.0], "longitude": [120.0]},
+        )
+        gpi_v = genesis_potential_index(vpi, eta_c)
+        assert "long_name" in gpi_v.attrs
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+
+class TestVentilationIntegration:
+    """Integration tests for the full ventilation pipeline."""
+
+    def test_full_pipeline(self, sample_atmospheric_dataset, sample_pi_field):
+        """Test the complete calculation chain: VWS → χ → VI → vPI → η_c → GPIv."""
+        ds = sample_atmospheric_dataset
+        pi = sample_pi_field
+
+        # Step 1: VWS
+        vws = vertical_wind_shear(ds)
+        assert "level" not in vws.dims
+
+        # Step 2: Entropy deficit
+        chi = entropy_deficit(ds)
+        assert "level" not in chi.dims
+
+        # Step 3: Ventilation index
+        vi = ventilation_index(vws, chi, pi)
+        valid_vi = vi.values[~np.isnan(vi.values)]
+        assert np.all(valid_vi > 0)
+
+        # Step 4: Ventilated PI
+        vpi = ventilated_pi(pi, vi)
+        valid_vpi = vpi.values[~np.isnan(vpi.values)]
+        assert np.all(valid_vpi > 0)
+        # vPI should be <= PI everywhere
+        valid_mask = np.isfinite(vpi.values) & np.isfinite(pi.values)
+        assert np.all(vpi.values[valid_mask] <= pi.values[valid_mask] + 1e-10)
+
+        # Step 5: Absolute vorticity
+        eta_c = absolute_vorticity_850(ds)
+        valid_eta = eta_c.values[~np.isnan(eta_c.values)]
+        assert np.all(valid_eta > 0)
+        assert np.all(np.abs(valid_eta) <= 3.7e-5 + 1e-15)
+
+        # Step 6: GPIv
+        gpi_v = genesis_potential_index(vpi, eta_c)
+        valid_gpi = gpi_v.values[~np.isnan(gpi_v.values)]
+        assert np.all(valid_gpi > 0)
+
+    def test_vpi_decreases_with_increasing_vi(self):
+        """vPI should decrease as VI increases (the core physics)."""
+        pi_val = 75.0
+        vi_low = xr.DataArray(np.array([0.02]), dims=["x"])
+        vi_high = xr.DataArray(np.array([0.12]), dims=["x"])
+        pi = xr.DataArray(np.array([pi_val]), dims=["x"])
+
+        vpi_low = ventilated_pi(pi, vi_low)
+        vpi_high = ventilated_pi(pi, vi_high)
+
+        assert vpi_high.values[0] < vpi_low.values[0]

--- a/tests/test_calc_ventilation.py
+++ b/tests/test_calc_ventilation.py
@@ -18,7 +18,6 @@ from skyborn.calc.ventilation import (
 )
 from skyborn.calc.ventilation.ventilation import VI_MAX
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -276,7 +275,9 @@ class TestVentilatedPI:
         vi = xr.DataArray(np.array([VI_MAX]), dims=["x"])
         vpi = ventilated_pi(pi, vi)
         expected_ratio = 1.0 / np.sqrt(3.0)
-        np.testing.assert_almost_equal(vpi.values[0], pi_val * expected_ratio, decimal=3)
+        np.testing.assert_almost_equal(
+            vpi.values[0], pi_val * expected_ratio, decimal=3
+        )
 
     def test_vi_above_vimax_is_nan(self):
         """VI > VI_MAX should produce NaN."""

--- a/tests/test_calc_ventilation.py
+++ b/tests/test_calc_ventilation.py
@@ -10,8 +10,10 @@ import xarray as xr
 
 from skyborn.calc.ventilation import (
     absolute_vorticity_850,
+    air_sea_disequilibrium,
     entropy_deficit,
     genesis_potential_index,
+    ventilation_components,
     ventilated_pi,
     ventilation_index,
     vertical_wind_shear,
@@ -96,6 +98,26 @@ def sample_pi_field(sample_atmospheric_dataset):
     return pi
 
 
+@pytest.fixture
+def sample_air_sea_disequilibrium(sample_atmospheric_dataset):
+    """Create a synthetic air-sea disequilibrium field matching the grid."""
+    ds = sample_atmospheric_dataset
+    asdeq = xr.DataArray(
+        np.full(
+            (ds.sizes["time"], ds.sizes["latitude"], ds.sizes["longitude"]),
+            90.0,
+        ),
+        dims=["time", "latitude", "longitude"],
+        coords={
+            "time": ds.time,
+            "latitude": ds.latitude,
+            "longitude": ds.longitude,
+        },
+        attrs={"units": "J kg^-1 K^-1", "long_name": "Air-Sea Disequilibrium"},
+    )
+    return asdeq
+
+
 # ---------------------------------------------------------------------------
 # vertical_wind_shear
 # ---------------------------------------------------------------------------
@@ -149,6 +171,12 @@ class TestVerticalWindShear:
         expected = np.full((2, 2), 5.0)
         np.testing.assert_array_almost_equal(vws.values, expected)
 
+    def test_custom_level_coord(self, sample_atmospheric_dataset):
+        ds = sample_atmospheric_dataset.rename({"level": "plev"})
+        vws = vertical_wind_shear(ds, level_coord="plev")
+        assert "plev" not in vws.dims
+        assert vws.sizes["time"] == ds.sizes["time"]
+
 
 # ---------------------------------------------------------------------------
 # entropy_deficit
@@ -158,47 +186,37 @@ class TestVerticalWindShear:
 class TestEntropyDeficit:
     """Tests for entropy_deficit."""
 
-    def test_returns_dataarray(self, sample_atmospheric_dataset):
-        chi = entropy_deficit(sample_atmospheric_dataset)
+    def test_returns_dataarray(
+        self, sample_atmospheric_dataset, sample_air_sea_disequilibrium
+    ):
+        chi = entropy_deficit(sample_atmospheric_dataset, sample_air_sea_disequilibrium)
         assert isinstance(chi, xr.DataArray)
 
-    def test_shape_no_level_dim(self, sample_atmospheric_dataset):
+    def test_shape_no_level_dim(
+        self, sample_atmospheric_dataset, sample_air_sea_disequilibrium
+    ):
         ds = sample_atmospheric_dataset
-        chi = entropy_deficit(ds)
+        chi = entropy_deficit(ds, sample_air_sea_disequilibrium)
         assert "level" not in chi.dims
 
-    def test_values_in_range(self, sample_atmospheric_dataset):
-        chi = entropy_deficit(sample_atmospheric_dataset)
+    def test_values_are_finite(
+        self, sample_atmospheric_dataset, sample_air_sea_disequilibrium
+    ):
+        chi = entropy_deficit(sample_atmospheric_dataset, sample_air_sea_disequilibrium)
         valid = chi.values[~np.isnan(chi.values)]
-        assert np.all(valid >= 0.02)
-        assert np.all(valid <= 1.5)
+        assert np.all(np.isfinite(valid))
 
-    def test_rh_based_calculation(self):
-        """Test that chi = 1 - RH/100 when R is available."""
+    def test_entropy_formula(self):
+        """Test the Chavas et al. entropy-deficit formula."""
         ds = xr.Dataset(
             data_vars={
-                "R": (
+                "T": (
                     ["level", "latitude", "longitude"],
-                    np.array([[[50, 60], [70, 80]]]),
+                    np.array([[[280.0, 285.0], [290.0, 295.0]]]),
                 ),
-            },
-            coords={
-                "level": [600],
-                "latitude": [0, 10],
-                "longitude": [0, 10],
-            },
-        )
-        chi = entropy_deficit(ds)
-        expected = np.array([[0.5, 0.4], [0.3, 0.2]])
-        np.testing.assert_array_almost_equal(chi.values, expected)
-
-    def test_q_fallback(self):
-        """Test specific humidity fallback when R is not available."""
-        ds = xr.Dataset(
-            data_vars={
                 "Q": (
                     ["level", "latitude", "longitude"],
-                    np.array([[[0.005, 0.010], [0.015, 0.020]]]),
+                    np.array([[[0.004, 0.006], [0.008, 0.010]]]),
                 ),
             },
             coords={
@@ -207,10 +225,42 @@ class TestEntropyDeficit:
                 "longitude": [0, 10],
             },
         )
-        chi = entropy_deficit(ds, rh_var="R_missing")
-        valid = chi.values[~np.isnan(chi.values)]
-        assert np.all(valid >= 0.02)
-        assert np.all(valid <= 1.5)
+        asdeq = xr.DataArray(
+            np.array([[80.0, 90.0], [100.0, 110.0]]),
+            dims=["latitude", "longitude"],
+            coords={
+                "latitude": [0, 10],
+                "longitude": [0, 10],
+            },
+        )
+        chi = entropy_deficit(ds, asdeq)
+        expected = np.array([[0.73283812, 0.86396779], [1.09802141, 1.44103677]])
+        np.testing.assert_allclose(chi.values, expected, rtol=1e-7)
+
+    def test_custom_level_coord(
+        self, sample_atmospheric_dataset, sample_air_sea_disequilibrium
+    ):
+        ds = sample_atmospheric_dataset.rename({"level": "plev"})
+        chi = entropy_deficit(
+            ds,
+            sample_air_sea_disequilibrium,
+            level_coord="plev",
+        )
+        assert "plev" not in chi.dims
+
+    def test_temperature_celsius_units(
+        self, sample_atmospheric_dataset, sample_air_sea_disequilibrium
+    ):
+        ds_kelvin = sample_atmospheric_dataset.copy()
+        ds_kelvin["T"].attrs["units"] = "K"
+        ds_celsius = sample_atmospheric_dataset.copy()
+        ds_celsius["T"] = ds_celsius["T"] - 273.15
+        ds_celsius["T"].attrs["units"] = "degC"
+
+        chi_kelvin = entropy_deficit(ds_kelvin, sample_air_sea_disequilibrium)
+        chi_celsius = entropy_deficit(ds_celsius, sample_air_sea_disequilibrium)
+
+        np.testing.assert_allclose(chi_celsius.values, chi_kelvin.values)
 
 
 # ---------------------------------------------------------------------------
@@ -221,10 +271,15 @@ class TestEntropyDeficit:
 class TestVentilationIndex:
     """Tests for ventilation_index."""
 
-    def test_returns_dataarray(self, sample_atmospheric_dataset, sample_pi_field):
+    def test_returns_dataarray(
+        self,
+        sample_atmospheric_dataset,
+        sample_pi_field,
+        sample_air_sea_disequilibrium,
+    ):
         ds = sample_atmospheric_dataset
         vws = vertical_wind_shear(ds)
-        chi = entropy_deficit(ds)
+        chi = entropy_deficit(ds, sample_air_sea_disequilibrium)
         vi = ventilation_index(vws, chi, sample_pi_field)
         assert isinstance(vi, xr.DataArray)
 
@@ -250,6 +305,30 @@ class TestVentilationIndex:
 # ---------------------------------------------------------------------------
 # ventilated_pi
 # ---------------------------------------------------------------------------
+
+
+class TestAirSeaDisequilibrium:
+    """Tests for air_sea_disequilibrium."""
+
+    def test_formula(self):
+        pi = xr.DataArray(np.array([80.0]), dims=["x"])
+        sst = xr.DataArray(np.array([300.0]), dims=["x"], attrs={"units": "K"})
+        t0 = xr.DataArray(np.array([280.0]), dims=["x"])
+        asdeq = air_sea_disequilibrium(pi, sst, t0, ckcd=0.9)
+        expected = 80.0**2 * (1.0 / 0.9) * 280.0 / (300.0 * (300.0 - 280.0))
+        np.testing.assert_allclose(asdeq.values, np.array([expected]))
+
+    def test_celsius_units(self):
+        pi = xr.DataArray(np.array([80.0]), dims=["x"])
+        sst_k = xr.DataArray(np.array([300.0]), dims=["x"], attrs={"units": "K"})
+        t0_k = xr.DataArray(np.array([280.0]), dims=["x"], attrs={"units": "K"})
+        sst_c = xr.DataArray(np.array([26.85]), dims=["x"], attrs={"units": "degC"})
+        t0_c = xr.DataArray(np.array([6.85]), dims=["x"], attrs={"units": "degC"})
+
+        asdeq_k = air_sea_disequilibrium(pi, sst_k, t0_k)
+        asdeq_c = air_sea_disequilibrium(pi, sst_c, t0_c)
+
+        np.testing.assert_allclose(asdeq_c.values, asdeq_k.values)
 
 
 class TestVentilatedPI:
@@ -329,6 +408,25 @@ class TestVentilatedPI:
         assert np.isfinite(vpi_custom.values[0])
         assert vpi_custom.values[0] < 70.0  # Should be reduced
 
+    def test_preserves_dask_laziness(self):
+        """vPI should not materialize dask-backed VI inputs."""
+        da = pytest.importorskip("dask.array")
+
+        pi = xr.DataArray(da.full((4,), 70.0, chunks=(2,)), dims=["x"])
+        vi = xr.DataArray(
+            da.from_array(np.array([0.02, 0.05, 0.10, 0.14]), chunks=(2,)),
+            dims=["x"],
+        )
+
+        vpi = ventilated_pi(pi, vi)
+        assert hasattr(vpi.data, "compute")
+
+        eager = ventilated_pi(
+            xr.DataArray(np.full(4, 70.0), dims=["x"]),
+            xr.DataArray(np.array([0.02, 0.05, 0.10, 0.14]), dims=["x"]),
+        )
+        np.testing.assert_allclose(vpi.compute().values, eager.values)
+
 
 # ---------------------------------------------------------------------------
 # absolute_vorticity_850
@@ -353,11 +451,11 @@ class TestAbsoluteVorticity850:
         valid = eta_c.values[~np.isnan(eta_c.values)]
         assert np.all(np.abs(valid) <= 3.7e-5 + 1e-15)
 
-    def test_values_positive(self, sample_atmospheric_dataset):
-        """All non-NaN values should be positive."""
+    def test_values_finite(self, sample_atmospheric_dataset):
+        """All non-NaN values should be finite."""
         eta_c = absolute_vorticity_850(sample_atmospheric_dataset)
         valid = eta_c.values[~np.isnan(eta_c.values)]
-        assert np.all(valid > 0)
+        assert np.all(np.isfinite(valid))
 
     def test_attrs_set(self, sample_atmospheric_dataset):
         eta_c = absolute_vorticity_850(sample_atmospheric_dataset)
@@ -369,6 +467,33 @@ class TestAbsoluteVorticity850:
         eta_c = absolute_vorticity_850(sample_atmospheric_dataset, cap=5.0e-5)
         valid = eta_c.values[~np.isnan(eta_c.values)]
         assert np.all(np.abs(valid) <= 5.0e-5 + 1e-15)
+
+    def test_southern_hemisphere_large_magnitude_vorticity_is_capped_positive(self):
+        """Large-magnitude negative absolute vorticity should remain usable."""
+        ds = xr.Dataset(
+            data_vars={
+                "U": (
+                    ["level", "latitude", "longitude"],
+                    np.zeros((1, 3, 3)),
+                ),
+                "V": (
+                    ["level", "latitude", "longitude"],
+                    np.zeros((1, 3, 3)),
+                ),
+            },
+            coords={
+                "level": [850],
+                "latitude": [-20.0, 0.0, 20.0],
+                "longitude": [0.0, 5.0, 10.0],
+            },
+        )
+        eta_c = absolute_vorticity_850(ds)
+        np.testing.assert_allclose(
+            eta_c.sel(latitude=-20.0).values,
+            np.full(3, 3.7e-5),
+            rtol=0,
+            atol=1e-15,
+        )
 
     def test_coriolis_at_equator(self):
         """At the equator, Coriolis should be ~0."""
@@ -390,10 +515,16 @@ class TestAbsoluteVorticity850:
             },
         )
         eta_c = absolute_vorticity_850(ds)
-        # At equator (latitude=0), Coriolis=0 and vorticity≈0 → should be NaN (filtered)
+        # At the equator, Coriolis=0 and vorticity is approximately 0.
         assert np.isnan(eta_c.sel(latitude=0.0).values).all() or np.all(
             eta_c.sel(latitude=0.0).values >= 0
         )
+
+    def test_custom_level_coord(self, sample_atmospheric_dataset):
+        ds = sample_atmospheric_dataset.rename({"level": "plev"})
+        eta_c = absolute_vorticity_850(ds, level_coord="plev")
+        assert "plev" not in eta_c.dims
+        assert eta_c.sizes["time"] == ds.sizes["time"]
 
 
 # ---------------------------------------------------------------------------
@@ -474,7 +605,12 @@ class TestGenesisPotentialIndex:
 class TestVentilationIntegration:
     """Integration tests for the full ventilation pipeline."""
 
-    def test_full_pipeline(self, sample_atmospheric_dataset, sample_pi_field):
+    def test_full_pipeline(
+        self,
+        sample_atmospheric_dataset,
+        sample_pi_field,
+        sample_air_sea_disequilibrium,
+    ):
         """Test the complete calculation chain: VWS → χ → VI → vPI → η_c → GPIv."""
         ds = sample_atmospheric_dataset
         pi = sample_pi_field
@@ -484,7 +620,7 @@ class TestVentilationIntegration:
         assert "level" not in vws.dims
 
         # Step 2: Entropy deficit
-        chi = entropy_deficit(ds)
+        chi = entropy_deficit(ds, sample_air_sea_disequilibrium)
         assert "level" not in chi.dims
 
         # Step 3: Ventilation index
@@ -503,7 +639,7 @@ class TestVentilationIntegration:
         # Step 5: Absolute vorticity
         eta_c = absolute_vorticity_850(ds)
         valid_eta = eta_c.values[~np.isnan(eta_c.values)]
-        assert np.all(valid_eta > 0)
+        assert np.all(np.isfinite(valid_eta))
         assert np.all(np.abs(valid_eta) <= 3.7e-5 + 1e-15)
 
         # Step 6: GPIv
@@ -522,3 +658,129 @@ class TestVentilationIntegration:
         vpi_high = ventilated_pi(pi, vi_high)
 
         assert vpi_high.values[0] < vpi_low.values[0]
+
+    def test_ventilation_components_reuses_gpi_xarray_diagnostics(
+        self, sample_atmospheric_dataset, monkeypatch
+    ):
+        """High-level pipeline should reuse the existing GPI xarray backend."""
+        import skyborn.calc.GPI.xarray as gpi_xarray
+
+        ds = sample_atmospheric_dataset.copy()
+        surface_shape = (
+            ds.sizes["time"],
+            ds.sizes["latitude"],
+            ds.sizes["longitude"],
+        )
+        ds["SSTK"] = (
+            ["time", "latitude", "longitude"],
+            np.full(surface_shape, 300.0),
+            {"units": "K"},
+        )
+        ds["SP"] = (
+            ["time", "latitude", "longitude"],
+            np.full(surface_shape, 100000.0),
+            {"units": "Pa"},
+        )
+
+        calls = {}
+
+        def fake_pi_log_decomposition(
+            sst, psl, pressure_levels, temperature, mixr, CKCD
+        ):
+            calls["called"] = True
+            calls["mixr"] = mixr
+            level_coord = pressure_levels.name
+            template = _drop_level_for_test(
+                temperature.sel({level_coord: 600}),
+                level_coord,
+            )
+            return xr.Dataset(
+                {
+                    "pi": xr.full_like(template, 80.0),
+                    "t0": xr.full_like(template, 280.0),
+                    "min_pressure": xr.full_like(template, 950.0),
+                    "error_flag": xr.DataArray(1),
+                }
+            )
+
+        monkeypatch.setattr(
+            gpi_xarray, "pi_log_decomposition", fake_pi_log_decomposition
+        )
+
+        result = ventilation_components(ds)
+
+        assert calls["called"] is True
+        assert calls["mixr"].attrs["units"] == "kg/kg"
+        assert set(
+            [
+                "PI",
+                "vPI",
+                "VWS",
+                "Chi",
+                "ventilation_index",
+                "eta_c",
+                "GPIv",
+                "air_sea_disequilibrium",
+            ]
+        ).issubset(result.data_vars)
+        assert result["PI"].sizes["time"] == ds.sizes["time"]
+
+    def test_ventilation_components_honors_level_coord_and_thresholds(
+        self, sample_atmospheric_dataset, monkeypatch
+    ):
+        """High-level pipeline should pass custom coordinates and thresholds down."""
+        import skyborn.calc.GPI.xarray as gpi_xarray
+
+        ds = sample_atmospheric_dataset.copy()
+        surface_shape = (
+            ds.sizes["time"],
+            ds.sizes["latitude"],
+            ds.sizes["longitude"],
+        )
+        ds["SSTK"] = (
+            ["time", "latitude", "longitude"],
+            np.full(surface_shape, 300.0),
+            {"units": "K"},
+        )
+        ds["SP"] = (
+            ["time", "latitude", "longitude"],
+            np.full(surface_shape, 100000.0),
+            {"units": "Pa"},
+        )
+        ds = ds.rename({"level": "plev"})
+
+        def fake_pi_log_decomposition(
+            sst, psl, pressure_levels, temperature, mixr, CKCD
+        ):
+            template = _drop_level_for_test(temperature.sel(plev=600), "plev")
+            return xr.Dataset(
+                {
+                    "pi": xr.full_like(template, 80.0),
+                    "t0": xr.full_like(template, 280.0),
+                    "min_pressure": xr.full_like(template, 950.0),
+                    "error_flag": xr.DataArray(1),
+                }
+            )
+
+        monkeypatch.setattr(
+            gpi_xarray, "pi_log_decomposition", fake_pi_log_decomposition
+        )
+
+        result = ventilation_components(
+            ds,
+            level_coord="plev",
+            vi_max=0.25,
+            vorticity_cap=5.0e-5,
+        )
+
+        assert "plev" not in result["VWS"].dims
+        assert "plev" not in result["Chi"].dims
+        assert "plev" not in result["eta_c"].dims
+        assert np.nanmax(np.abs(result["eta_c"].values)) <= 5.0e-5 + 1e-15
+
+
+def _drop_level_for_test(da, level_coord="level"):
+    """Drop scalar level coordinate in tests without importing private helpers."""
+    if level_coord in da.coords and level_coord not in da.dims:
+        return da.drop_vars(level_coord)
+    return da


### PR DESCRIPTION
Implements the ventilated potential intensity (vPI) framework and the ventilated genesis potential index (GPIv) from Chavas, Camargo & Tippett (2025, J. Climate, https://doi.org/10.1175/JCLI-D-24-0186.1).

New module: skyborn.calc.ventilation
- vertical_wind_shear: 200-850 hPa wind shear magnitude
- entropy_deficit: 600-hPa RH-based entropy deficit proxy (Chi)
- ventilation_index: VI = VWS * Chi / PI (Tang & Emanuel 2012)
- ventilated_pi: analytic cubic solution for vPI (Cardano formula)
- absolute_vorticity_850: clipped 850-hPa absolute vorticity
- genesis_potential_index: GPIv = (102.1 * vPI * eta_c)^4.90 * cos(lat) * dx * dy

Key implementation details:
- vPI cubic solution verified: ratio=1/sqrt(3) at VI=VI_MAX (0.145)
- All functions accept/return xarray.DataArray for gridded data compatibility
- 35 unit tests covering formula correctness, edge cases, and integration

References:
  Chavas et al. 2025, J. Climate, 38, 1667-1689 Tang & Emanuel 2012, Bull. Amer. Meteor. Soc., 93, 1901-1912