### PR TITLE
feat(calc): add CAPE/CIN, most-unstable parcel, and SRH with Fortran/…

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -38,18 +38,19 @@ jobs:
           - [macos-15, macosx_arm64] # macOS Apple Silicon
           - [windows-2022, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
-        # exclude:
-        #   # manylinux2014 (CentOS7/glibc 2.17) only ships cp39 and cp310 interpreters.
-        #   # Users on Python 3.11+ almost always have glibc > 2.17 and can use manylinux_2_28 wheels.
-        #   - buildplat: [ubuntu-latest, manylinux2014_x86_64]
-        #     python: "cp311"
-        #   - buildplat: [ubuntu-latest, manylinux2014_x86_64]
-        #     python: "cp312"
-        #   - buildplat: [ubuntu-latest, manylinux2014_x86_64]
-        #     python: "cp313"
-        #   - buildplat: [ubuntu-latest, manylinux2014_x86_64]
-        #     python: "cp314"
-        # exclude:
+        exclude:
+          # manylinux2014 (CentOS7/glibc 2.17) only ships cp39 and cp310
+          # interpreters; cp311+ builds are unreliable on that image.
+          # Users on Python 3.11+ almost always have glibc > 2.17 and can use
+          # manylinux_2_28 wheels.
+          - buildplat: [ubuntu-latest, manylinux2014_x86_64]
+            python: "cp311"
+          - buildplat: [ubuntu-latest, manylinux2014_x86_64]
+            python: "cp312"
+          - buildplat: [ubuntu-latest, manylinux2014_x86_64]
+            python: "cp313"
+          - buildplat: [ubuntu-latest, manylinux2014_x86_64]
+            python: "cp314"
         #   # Exclude unsupported Python versions on ARM64 Linux
         #   - buildplat: [ubuntu-22.04, manylinux_aarch64]
         #     python: "cp39"  # Python 3.9 not available in ARM64 images

--- a/src/skyborn/calc/__init__.py
+++ b/src/skyborn/calc/__init__.py
@@ -22,13 +22,14 @@ from typing import Any
 
 _SUBMODULE_EXPORTS = {
     "GPI",
+    "cape",
     "dcape",
     "geostrophic",
     "growth_rate",
     "mann_kendall",
+    "srh",
     "troposphere",
 }
-
 _OBJECT_EXPORTS = {
     # Statistical calculations.
     "calculate_potential_temperature": (
@@ -45,6 +46,21 @@ _OBJECT_EXPORTS = {
     "spatial_correlation": ("skyborn.calc.calculations", "spatial_correlation"),
     "spearman_correlation": ("skyborn.calc.calculations", "spearman_correlation"),
     "calculate_dcape": ("skyborn.calc.dcape", "calculate_dcape"),
+    # CAPE/CIN diagnostics (Fortran/C extension).
+    "calculate_cape_cin": ("skyborn.calc.cape", "calculate_cape_cin"),
+    "calculate_parcel_profile": ("skyborn.calc.cape", "calculate_parcel_profile"),
+    "calculate_most_unstable_parcel": (
+        "skyborn.calc.cape",
+        "calculate_most_unstable_parcel",
+    ),
+    "calculate_most_unstable_cape_cin": (
+        "skyborn.calc.cape",
+        "calculate_most_unstable_cape_cin",
+    ),
+    "calculate_storm_relative_helicity": (
+        "skyborn.calc.srh",
+        "calculate_storm_relative_helicity",
+    ),
     # Emergent constraints.
     "calc_GAUSSIAN_PDF": (
         "skyborn.calc.emergent_constraints",

--- a/src/skyborn/calc/cape/__init__.py
+++ b/src/skyborn/calc/cape/__init__.py
@@ -1,0 +1,14 @@
+"""CAPE/CIN calculations for Skyborn."""
+from .core import (
+    calculate_cape_cin,
+    calculate_most_unstable_cape_cin,
+    calculate_most_unstable_parcel,
+    calculate_parcel_profile,
+)
+
+__all__ = [
+    "calculate_cape_cin",
+    "calculate_parcel_profile",
+    "calculate_most_unstable_parcel",
+    "calculate_most_unstable_cape_cin",
+]

--- a/src/skyborn/calc/cape/cape_core_module.c
+++ b/src/skyborn/calc/cape/cape_core_module.c
@@ -1,0 +1,665 @@
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_19_API_VERSION
+#include <Python.h>
+#include <numpy/arrayobject.h>
+
+/* Fortran kernels (bind(C)) */
+void cape_profile_c(
+    int nlev, void *pressure_hpa, void *temperature_c, void *dewpoint_c,
+    void *cape, void *cin, void *lfc_p, void *el_p);
+void cape_grid_c(
+    int nlev, int nlat, int nlon,
+    void *pressure_3d, void *t_3d, void *td_3d,
+    void *cape2, void *cin2, void *lfc2, void *el2);
+void parcel_profile_c(
+    int nlev, void *pressure_hpa, void *temperature_c, void *dewpoint_c, void *t_par_c);
+void parcel_profile_grid_c(
+    int nlev, int nlat, int nlon,
+    void *pressure_3d, void *t_3d, void *td_3d, void *out_3d);
+void most_unstable_parcel_c(
+    int nlev, void *pressure_hpa, void *temperature_c, void *dewpoint_c,
+    double depth_hpa, void *mup_p, void *mup_t, void *mup_td, int *mup_idx);
+void most_unstable_parcel_grid_c(
+    int nlev, int nlat, int nlon,
+    void *pressure_3d, void *t_3d, void *td_3d, double depth_hpa,
+    void *out_p3, void *out_t3, void *out_td3, int *out_idx3);
+void mucape_c(
+    int nlev, void *pressure_hpa, void *temperature_c, void *dewpoint_c,
+    double depth_hpa, void *cape, void *cin, void *lfc_p, void *el_p);
+void mucape_grid_c(
+    int nlev, int nlat, int nlon,
+    void *pressure_3d, void *t_3d, void *td_3d, double depth_hpa,
+    void *cape2, void *cin2, void *lfc2, void *el2);
+
+static int check_3d_shapes(PyArrayObject *p, PyArrayObject *t, PyArrayObject *td)
+{
+    npy_intp nlev, nlat, nlon;
+    nlev = PyArray_DIM(p, 0);
+    nlat = PyArray_DIM(p, 1);
+    nlon = PyArray_DIM(p, 2);
+    if (PyArray_DIM(t, 0) != nlev || PyArray_DIM(t, 1) != nlat || PyArray_DIM(t, 2) != nlon ||
+        PyArray_DIM(td, 0) != nlev || PyArray_DIM(td, 1) != nlat || PyArray_DIM(td, 2) != nlon)
+    {
+        PyErr_SetString(PyExc_ValueError, "pressure, temperature, and dewpoint must share a shape");
+        return 0;
+    }
+    return 1;
+}
+
+/* ---------------- cape_profile: single vertical profile ---------------- */
+static PyObject *py_cape_profile(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *pressure_obj = NULL;
+    PyObject *temperature_obj = NULL;
+    PyObject *dewpoint_obj = NULL;
+    PyArrayObject *pressure_arr = NULL;
+    PyArrayObject *temperature_arr = NULL;
+    PyArrayObject *dewpoint_arr = NULL;
+    double cape = 0.0, cin = 0.0, lfc_p = 0.0, el_p = 0.0;
+    int nlev;
+    static char *kwlist[] = {"pressure", "temperature", "dewpoint", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO", kwlist,
+                                     &pressure_obj, &temperature_obj, &dewpoint_obj))
+    {
+        return NULL;
+    }
+    pressure_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        pressure_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    temperature_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        temperature_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    dewpoint_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        dewpoint_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    if (pressure_arr == NULL || temperature_arr == NULL || dewpoint_arr == NULL)
+    {
+        Py_XDECREF(pressure_arr);
+        Py_XDECREF(temperature_arr);
+        Py_XDECREF(dewpoint_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(pressure_arr) != 1 || PyArray_NDIM(temperature_arr) != 1 ||
+        PyArray_NDIM(dewpoint_arr) != 1)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "pressure, temperature, and dewpoint must be 1D arrays");
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(pressure_arr, 0);
+    if ((int) PyArray_DIM(temperature_arr, 0) != nlev ||
+        (int) PyArray_DIM(dewpoint_arr, 0) != nlev)
+    {
+        PyErr_SetString(PyExc_ValueError, "pressure, temperature, and dewpoint must share a length");
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    cape_profile_c(nlev, PyArray_DATA(pressure_arr), PyArray_DATA(temperature_arr),
+                   PyArray_DATA(dewpoint_arr), &cape, &cin, &lfc_p, &el_p);
+    Py_END_ALLOW_THREADS
+    Py_DECREF(pressure_arr);
+    Py_DECREF(temperature_arr);
+    Py_DECREF(dewpoint_arr);
+    return Py_BuildValue("dddd", cape, cin, lfc_p, el_p);
+fail:
+    Py_XDECREF(pressure_arr);
+    Py_XDECREF(temperature_arr);
+    Py_XDECREF(dewpoint_arr);
+    return NULL;
+}
+
+/* ---------------- cape_grid: 3D grid of profiles ---------------- */
+static PyObject *py_cape_grid(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *pressure_obj = NULL;
+    PyObject *temperature_obj = NULL;
+    PyObject *dewpoint_obj = NULL;
+    PyArrayObject *pressure_arr = NULL;
+    PyArrayObject *temperature_arr = NULL;
+    PyArrayObject *dewpoint_arr = NULL;
+    PyArrayObject *cape_arr = NULL;
+    PyArrayObject *cin_arr = NULL;
+    PyArrayObject *lfc_arr = NULL;
+    PyArrayObject *el_arr = NULL;
+    PyObject *result = NULL;
+    npy_intp dims[2];
+    int nlev, nlat, nlon;
+    static char *kwlist[] = {"pressure", "temperature", "dewpoint", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO", kwlist,
+                                     &pressure_obj, &temperature_obj, &dewpoint_obj))
+    {
+        return NULL;
+    }
+    pressure_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        pressure_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    temperature_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        temperature_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    dewpoint_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        dewpoint_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    if (pressure_arr == NULL || temperature_arr == NULL || dewpoint_arr == NULL)
+    {
+        Py_XDECREF(pressure_arr);
+        Py_XDECREF(temperature_arr);
+        Py_XDECREF(dewpoint_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(pressure_arr) != 3 || PyArray_NDIM(temperature_arr) != 3 ||
+        PyArray_NDIM(dewpoint_arr) != 3)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "pressure, temperature, and dewpoint must be 3D arrays");
+        goto fail;
+    }
+    if (!check_3d_shapes(pressure_arr, temperature_arr, dewpoint_arr))
+    {
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(pressure_arr, 0);
+    nlat = (int) PyArray_DIM(pressure_arr, 1);
+    nlon = (int) PyArray_DIM(pressure_arr, 2);
+    dims[0] = nlat;
+    dims[1] = nlon;
+    cape_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    cin_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    lfc_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    el_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    if (cape_arr == NULL || cin_arr == NULL || lfc_arr == NULL || el_arr == NULL)
+    {
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    cape_grid_c(nlev, nlat, nlon,
+                PyArray_DATA(pressure_arr), PyArray_DATA(temperature_arr),
+                PyArray_DATA(dewpoint_arr), PyArray_DATA(cape_arr),
+                PyArray_DATA(cin_arr), PyArray_DATA(lfc_arr), PyArray_DATA(el_arr));
+    Py_END_ALLOW_THREADS
+    result = Py_BuildValue("NNNN", (PyObject *) cape_arr, (PyObject *) cin_arr,
+                           (PyObject *) lfc_arr, (PyObject *) el_arr);
+    Py_DECREF(pressure_arr);
+    Py_DECREF(temperature_arr);
+    Py_DECREF(dewpoint_arr);
+    return result;
+fail:
+    Py_XDECREF(pressure_arr);
+    Py_XDECREF(temperature_arr);
+    Py_XDECREF(dewpoint_arr);
+    Py_XDECREF(cape_arr);
+    Py_XDECREF(cin_arr);
+    Py_XDECREF(lfc_arr);
+    Py_XDECREF(el_arr);
+    return NULL;
+}
+
+/* ---------------- parcel_profile: single profile ---------------- */
+static PyObject *py_parcel_profile(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *pressure_obj = NULL;
+    PyObject *temperature_obj = NULL;
+    PyObject *dewpoint_obj = NULL;
+    PyArrayObject *pressure_arr = NULL;
+    PyArrayObject *temperature_arr = NULL;
+    PyArrayObject *dewpoint_arr = NULL;
+    PyArrayObject *out_arr = NULL;
+    npy_intp dims[1];
+    int nlev;
+    static char *kwlist[] = {"pressure", "temperature", "dewpoint", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO", kwlist,
+                                     &pressure_obj, &temperature_obj, &dewpoint_obj))
+    {
+        return NULL;
+    }
+    pressure_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        pressure_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    temperature_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        temperature_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    dewpoint_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        dewpoint_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    if (pressure_arr == NULL || temperature_arr == NULL || dewpoint_arr == NULL)
+    {
+        Py_XDECREF(pressure_arr);
+        Py_XDECREF(temperature_arr);
+        Py_XDECREF(dewpoint_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(pressure_arr) != 1 || PyArray_NDIM(temperature_arr) != 1 ||
+        PyArray_NDIM(dewpoint_arr) != 1)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "pressure, temperature, and dewpoint must be 1D arrays");
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(pressure_arr, 0);
+    if ((int) PyArray_DIM(temperature_arr, 0) != nlev ||
+        (int) PyArray_DIM(dewpoint_arr, 0) != nlev)
+    {
+        PyErr_SetString(PyExc_ValueError, "pressure, temperature, and dewpoint must share a length");
+        goto fail;
+    }
+    dims[0] = nlev;
+    out_arr = (PyArrayObject *) PyArray_EMPTY(1, dims, NPY_FLOAT64, 0);
+    if (out_arr == NULL)
+    {
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    parcel_profile_c(nlev, PyArray_DATA(pressure_arr), PyArray_DATA(temperature_arr),
+                     PyArray_DATA(dewpoint_arr), PyArray_DATA(out_arr));
+    Py_END_ALLOW_THREADS
+    Py_DECREF(pressure_arr);
+    Py_DECREF(temperature_arr);
+    Py_DECREF(dewpoint_arr);
+    return (PyObject *) out_arr;
+fail:
+    Py_XDECREF(pressure_arr);
+    Py_XDECREF(temperature_arr);
+    Py_XDECREF(dewpoint_arr);
+    Py_XDECREF(out_arr);
+    return NULL;
+}
+
+/* ---------------- parcel_profile_grid: 3D grid ---------------- */
+static PyObject *py_parcel_profile_grid(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *pressure_obj = NULL;
+    PyObject *temperature_obj = NULL;
+    PyObject *dewpoint_obj = NULL;
+    PyArrayObject *pressure_arr = NULL;
+    PyArrayObject *temperature_arr = NULL;
+    PyArrayObject *dewpoint_arr = NULL;
+    PyArrayObject *out_arr = NULL;
+    npy_intp dims[3];
+    int nlev, nlat, nlon;
+    static char *kwlist[] = {"pressure", "temperature", "dewpoint", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO", kwlist,
+                                     &pressure_obj, &temperature_obj, &dewpoint_obj))
+    {
+        return NULL;
+    }
+    pressure_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        pressure_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    temperature_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        temperature_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    dewpoint_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        dewpoint_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    if (pressure_arr == NULL || temperature_arr == NULL || dewpoint_arr == NULL)
+    {
+        Py_XDECREF(pressure_arr);
+        Py_XDECREF(temperature_arr);
+        Py_XDECREF(dewpoint_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(pressure_arr) != 3 || PyArray_NDIM(temperature_arr) != 3 ||
+        PyArray_NDIM(dewpoint_arr) != 3)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "pressure, temperature, and dewpoint must be 3D arrays");
+        goto fail;
+    }
+    if (!check_3d_shapes(pressure_arr, temperature_arr, dewpoint_arr))
+    {
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(pressure_arr, 0);
+    nlat = (int) PyArray_DIM(pressure_arr, 1);
+    nlon = (int) PyArray_DIM(pressure_arr, 2);
+    dims[0] = nlev;
+    dims[1] = nlat;
+    dims[2] = nlon;
+    out_arr = (PyArrayObject *) PyArray_EMPTY(3, dims, NPY_FLOAT64, 1);
+    if (out_arr == NULL)
+    {
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    parcel_profile_grid_c(nlev, nlat, nlon, PyArray_DATA(pressure_arr),
+                          PyArray_DATA(temperature_arr), PyArray_DATA(dewpoint_arr),
+                          PyArray_DATA(out_arr));
+    Py_END_ALLOW_THREADS
+    Py_DECREF(pressure_arr);
+    Py_DECREF(temperature_arr);
+    Py_DECREF(dewpoint_arr);
+    return (PyObject *) out_arr;
+fail:
+    Py_XDECREF(pressure_arr);
+    Py_XDECREF(temperature_arr);
+    Py_XDECREF(dewpoint_arr);
+    Py_XDECREF(out_arr);
+    return NULL;
+}
+
+/* ---------------- most_unstable_parcel: single profile ---------------- */
+static PyObject *py_most_unstable_parcel(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *pressure_obj = NULL;
+    PyObject *temperature_obj = NULL;
+    PyObject *dewpoint_obj = NULL;
+    PyArrayObject *pressure_arr = NULL;
+    PyArrayObject *temperature_arr = NULL;
+    PyArrayObject *dewpoint_arr = NULL;
+    double depth = 300.0, mup_p = 0.0, mup_t = 0.0, mup_td = 0.0;
+    int mup_idx = -1, nlev;
+    static char *kwlist[] = {"pressure", "temperature", "dewpoint", "depth", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO|d", kwlist,
+                                     &pressure_obj, &temperature_obj, &dewpoint_obj, &depth))
+    {
+        return NULL;
+    }
+    pressure_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        pressure_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    temperature_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        temperature_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    dewpoint_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        dewpoint_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    if (pressure_arr == NULL || temperature_arr == NULL || dewpoint_arr == NULL)
+    {
+        Py_XDECREF(pressure_arr);
+        Py_XDECREF(temperature_arr);
+        Py_XDECREF(dewpoint_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(pressure_arr) != 1 || PyArray_NDIM(temperature_arr) != 1 ||
+        PyArray_NDIM(dewpoint_arr) != 1)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "pressure, temperature, and dewpoint must be 1D arrays");
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(pressure_arr, 0);
+    if ((int) PyArray_DIM(temperature_arr, 0) != nlev ||
+        (int) PyArray_DIM(dewpoint_arr, 0) != nlev)
+    {
+        PyErr_SetString(PyExc_ValueError, "pressure, temperature, and dewpoint must share a length");
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    most_unstable_parcel_c(nlev, PyArray_DATA(pressure_arr), PyArray_DATA(temperature_arr),
+                           PyArray_DATA(dewpoint_arr), depth, &mup_p, &mup_t, &mup_td, &mup_idx);
+    Py_END_ALLOW_THREADS
+    Py_DECREF(pressure_arr);
+    Py_DECREF(temperature_arr);
+    Py_DECREF(dewpoint_arr);
+    return Py_BuildValue("dddi", mup_p, mup_t, mup_td, mup_idx);
+fail:
+    Py_XDECREF(pressure_arr);
+    Py_XDECREF(temperature_arr);
+    Py_XDECREF(dewpoint_arr);
+    return NULL;
+}
+
+/* ---------------- most_unstable_parcel: 3D grid ---------------- */
+static PyObject *py_most_unstable_parcel_grid(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *pressure_obj = NULL;
+    PyObject *temperature_obj = NULL;
+    PyObject *dewpoint_obj = NULL;
+    PyArrayObject *pressure_arr = NULL;
+    PyArrayObject *temperature_arr = NULL;
+    PyArrayObject *dewpoint_arr = NULL;
+    PyArrayObject *p_arr = NULL, *t_arr = NULL, *td_arr = NULL, *idx_arr = NULL;
+    PyObject *result = NULL;
+    npy_intp dims[3];
+    double depth = 300.0;
+    int nlev, nlat, nlon;
+    static char *kwlist[] = {"pressure", "temperature", "dewpoint", "depth", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO|d", kwlist,
+                                     &pressure_obj, &temperature_obj, &dewpoint_obj, &depth))
+    {
+        return NULL;
+    }
+    pressure_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        pressure_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    temperature_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        temperature_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    dewpoint_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        dewpoint_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    if (pressure_arr == NULL || temperature_arr == NULL || dewpoint_arr == NULL)
+    {
+        Py_XDECREF(pressure_arr);
+        Py_XDECREF(temperature_arr);
+        Py_XDECREF(dewpoint_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(pressure_arr) != 3 || PyArray_NDIM(temperature_arr) != 3 ||
+        PyArray_NDIM(dewpoint_arr) != 3)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "pressure, temperature, and dewpoint must be 3D arrays");
+        goto fail;
+    }
+    if (!check_3d_shapes(pressure_arr, temperature_arr, dewpoint_arr))
+    {
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(pressure_arr, 0);
+    nlat = (int) PyArray_DIM(pressure_arr, 1);
+    nlon = (int) PyArray_DIM(pressure_arr, 2);
+    dims[0] = nlev;
+    dims[1] = nlat;
+    dims[2] = nlon;
+    p_arr = (PyArrayObject *) PyArray_EMPTY(3, dims, NPY_FLOAT64, 1);
+    t_arr = (PyArrayObject *) PyArray_EMPTY(3, dims, NPY_FLOAT64, 1);
+    td_arr = (PyArrayObject *) PyArray_EMPTY(3, dims, NPY_FLOAT64, 1);
+    idx_arr = (PyArrayObject *) PyArray_EMPTY(3, dims, NPY_INT32, 1);
+    if (p_arr == NULL || t_arr == NULL || td_arr == NULL || idx_arr == NULL)
+    {
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    most_unstable_parcel_grid_c(nlev, nlat, nlon, PyArray_DATA(pressure_arr),
+                                PyArray_DATA(temperature_arr), PyArray_DATA(dewpoint_arr),
+                                depth, PyArray_DATA(p_arr), PyArray_DATA(t_arr),
+                                PyArray_DATA(td_arr), (int *) PyArray_DATA(idx_arr));
+    Py_END_ALLOW_THREADS
+    result = Py_BuildValue("NNNN", (PyObject *) p_arr, (PyObject *) t_arr,
+                           (PyObject *) td_arr, (PyObject *) idx_arr);
+    Py_DECREF(pressure_arr);
+    Py_DECREF(temperature_arr);
+    Py_DECREF(dewpoint_arr);
+    return result;
+fail:
+    Py_XDECREF(pressure_arr);
+    Py_XDECREF(temperature_arr);
+    Py_XDECREF(dewpoint_arr);
+    Py_XDECREF(p_arr);
+    Py_XDECREF(t_arr);
+    Py_XDECREF(td_arr);
+    Py_XDECREF(idx_arr);
+    return NULL;
+}
+
+/* ---------------- most unstable CAPE/CIN: single profile ---------------- */
+static PyObject *py_mucape_profile(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *pressure_obj = NULL;
+    PyObject *temperature_obj = NULL;
+    PyObject *dewpoint_obj = NULL;
+    PyArrayObject *pressure_arr = NULL;
+    PyArrayObject *temperature_arr = NULL;
+    PyArrayObject *dewpoint_arr = NULL;
+    double depth = 300.0, cape = 0.0, cin = 0.0, lfc_p = 0.0, el_p = 0.0;
+    int nlev;
+    static char *kwlist[] = {"pressure", "temperature", "dewpoint", "depth", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO|d", kwlist,
+                                     &pressure_obj, &temperature_obj, &dewpoint_obj, &depth))
+    {
+        return NULL;
+    }
+    pressure_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        pressure_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    temperature_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        temperature_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    dewpoint_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        dewpoint_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    if (pressure_arr == NULL || temperature_arr == NULL || dewpoint_arr == NULL)
+    {
+        Py_XDECREF(pressure_arr);
+        Py_XDECREF(temperature_arr);
+        Py_XDECREF(dewpoint_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(pressure_arr) != 1 || PyArray_NDIM(temperature_arr) != 1 ||
+        PyArray_NDIM(dewpoint_arr) != 1)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "pressure, temperature, and dewpoint must be 1D arrays");
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(pressure_arr, 0);
+    if ((int) PyArray_DIM(temperature_arr, 0) != nlev ||
+        (int) PyArray_DIM(dewpoint_arr, 0) != nlev)
+    {
+        PyErr_SetString(PyExc_ValueError, "pressure, temperature, and dewpoint must share a length");
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    mucape_c(nlev, PyArray_DATA(pressure_arr), PyArray_DATA(temperature_arr),
+             PyArray_DATA(dewpoint_arr), depth, &cape, &cin, &lfc_p, &el_p);
+    Py_END_ALLOW_THREADS
+    Py_DECREF(pressure_arr);
+    Py_DECREF(temperature_arr);
+    Py_DECREF(dewpoint_arr);
+    return Py_BuildValue("dddd", cape, cin, lfc_p, el_p);
+fail:
+    Py_XDECREF(pressure_arr);
+    Py_XDECREF(temperature_arr);
+    Py_XDECREF(dewpoint_arr);
+    return NULL;
+}
+
+/* ---------------- most unstable CAPE/CIN: 3D grid ---------------- */
+static PyObject *py_mucape_grid(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *pressure_obj = NULL;
+    PyObject *temperature_obj = NULL;
+    PyObject *dewpoint_obj = NULL;
+    PyArrayObject *pressure_arr = NULL;
+    PyArrayObject *temperature_arr = NULL;
+    PyArrayObject *dewpoint_arr = NULL;
+    PyArrayObject *cape_arr = NULL, *cin_arr = NULL, *lfc_arr = NULL, *el_arr = NULL;
+    PyObject *result = NULL;
+    npy_intp dims[2];
+    double depth = 300.0;
+    int nlev, nlat, nlon;
+    static char *kwlist[] = {"pressure", "temperature", "dewpoint", "depth", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO|d", kwlist,
+                                     &pressure_obj, &temperature_obj, &dewpoint_obj, &depth))
+    {
+        return NULL;
+    }
+    pressure_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        pressure_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    temperature_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        temperature_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    dewpoint_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        dewpoint_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    if (pressure_arr == NULL || temperature_arr == NULL || dewpoint_arr == NULL)
+    {
+        Py_XDECREF(pressure_arr);
+        Py_XDECREF(temperature_arr);
+        Py_XDECREF(dewpoint_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(pressure_arr) != 3 || PyArray_NDIM(temperature_arr) != 3 ||
+        PyArray_NDIM(dewpoint_arr) != 3)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "pressure, temperature, and dewpoint must be 3D arrays");
+        goto fail;
+    }
+    if (!check_3d_shapes(pressure_arr, temperature_arr, dewpoint_arr))
+    {
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(pressure_arr, 0);
+    nlat = (int) PyArray_DIM(pressure_arr, 1);
+    nlon = (int) PyArray_DIM(pressure_arr, 2);
+    dims[0] = nlat;
+    dims[1] = nlon;
+    cape_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    cin_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    lfc_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    el_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    if (cape_arr == NULL || cin_arr == NULL || lfc_arr == NULL || el_arr == NULL)
+    {
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    mucape_grid_c(nlev, nlat, nlon, PyArray_DATA(pressure_arr), PyArray_DATA(temperature_arr),
+                  PyArray_DATA(dewpoint_arr), depth, PyArray_DATA(cape_arr),
+                  PyArray_DATA(cin_arr), PyArray_DATA(lfc_arr), PyArray_DATA(el_arr));
+    Py_END_ALLOW_THREADS
+    result = Py_BuildValue("NNNN", (PyObject *) cape_arr, (PyObject *) cin_arr,
+                           (PyObject *) lfc_arr, (PyObject *) el_arr);
+    Py_DECREF(pressure_arr);
+    Py_DECREF(temperature_arr);
+    Py_DECREF(dewpoint_arr);
+    return result;
+fail:
+    Py_XDECREF(pressure_arr);
+    Py_XDECREF(temperature_arr);
+    Py_XDECREF(dewpoint_arr);
+    Py_XDECREF(cape_arr);
+    Py_XDECREF(cin_arr);
+    Py_XDECREF(lfc_arr);
+    Py_XDECREF(el_arr);
+    return NULL;
+}
+
+static PyMethodDef module_methods[] = {
+    {"cape_profile", (PyCFunction) (void (*)(void)) py_cape_profile,
+     METH_VARARGS | METH_KEYWORDS,
+     "Compute CAPE, CIN, LFC pressure, and EL pressure for a single profile."},
+    {"cape_grid", (PyCFunction) (void (*)(void)) py_cape_grid,
+     METH_VARARGS | METH_KEYWORDS,
+     "Compute CAPE, CIN, LFC pressure, and EL pressure for a 3D grid of profiles."},
+    {"parcel_profile", (PyCFunction) (void (*)(void)) py_parcel_profile,
+     METH_VARARGS | METH_KEYWORDS,
+     "Compute the surface-based parcel temperature profile."},
+    {"parcel_profile_grid", (PyCFunction) (void (*)(void)) py_parcel_profile_grid,
+     METH_VARARGS | METH_KEYWORDS,
+     "Compute parcel temperature profiles for a 3D grid."},
+    {"most_unstable_parcel", (PyCFunction) (void (*)(void)) py_most_unstable_parcel,
+     METH_VARARGS | METH_KEYWORDS,
+     "Find the most unstable parcel (max theta-e) within the bottom-depth layer."},
+    {"most_unstable_parcel_grid", (PyCFunction) (void (*)(void)) py_most_unstable_parcel_grid,
+     METH_VARARGS | METH_KEYWORDS,
+     "Find the most unstable parcel for every column of a 3D grid."},
+    {"mucape_profile", (PyCFunction) (void (*)(void)) py_mucape_profile,
+     METH_VARARGS | METH_KEYWORDS,
+     "Compute most unstable CAPE, CIN, LFC pressure, and EL pressure."},
+    {"mucape_grid", (PyCFunction) (void (*)(void)) py_mucape_grid,
+     METH_VARARGS | METH_KEYWORDS,
+     "Compute most unstable CAPE/CIN for a 3D grid of profiles."},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "cape_core",
+    NULL,
+    -1,
+    module_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+PyMODINIT_FUNC PyInit_cape_core(void)
+{
+    import_array();
+    return PyModule_Create(&moduledef);
+}

--- a/src/skyborn/calc/cape/core.py
+++ b/src/skyborn/calc/cape/core.py
@@ -1,0 +1,425 @@
+"""CAPE/CIN calculations backed by the compiled Fortran/C extension.
+
+This module mirrors the ``skyborn.calc.dcape`` layout: a compiled backend
+handles the per-profile numerics, while this Python layer handles shape
+dispatch (1D profile -> scalars, 3D grid -> 2D fields) and optional
+xarray metadata preservation.
+
+Input convention (same as the DCAPE backend):
+
+* ``pressure``    in hPa
+* ``temperature`` in Celsius
+* ``dewpoint``    in Celsius
+
+Outputs:
+
+* ``cape`` / ``cin``  in J kg^-1 (CIN is reported <= 0, matching metpy)
+* ``lfc_p`` / ``el_p`` in hPa
+* parcel profile temperatures in Celsius
+
+The parcel is a surface-based parcel: dry adiabatic ascent to the
+Bolton-approximation LCL, then a fixed-step RK4 moist pseudo-adiabat.
+CAPE/CIN follow metpy's convention (``which_lfc='bottom'``,
+``which_el='top'``), integrated against ln(p) with zero crossings
+inserted by log-pressure linear interpolation.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Union
+
+import numpy as np
+import xarray as xr
+
+__all__ = [
+    "calculate_cape_cin",
+    "cape_profile",
+    "cape_grid",
+    "calculate_parcel_profile",
+    "parcel_profile",
+    "parcel_profile_grid",
+    "calculate_most_unstable_parcel",
+    "most_unstable_parcel",
+    "most_unstable_parcel_grid",
+    "calculate_most_unstable_cape_cin",
+    "most_unstable_cape_cin",
+    "most_unstable_cape_cin_grid",
+]
+
+_BACKEND = import_module(f"{__package__}.cape_core")
+
+
+def _as_numpy(values):
+    """Extract a NumPy array from xarray-like or array-like inputs."""
+    return getattr(values, "values", values)
+
+
+def _wrap_xarray_result(pressure: xr.DataArray, values: np.ndarray) -> xr.DataArray:
+    """Preserve xarray metadata for a 2D CAPE result field."""
+    dims = list(pressure.dims[-2:])
+    coords = {}
+    for dim in dims:
+        if dim in pressure.coords:
+            coords[dim] = pressure.coords[dim]
+    return xr.DataArray(
+        values,
+        dims=dims or ["y", "x"],
+        coords=coords,
+        attrs={"units": "J kg-1", "long_name": "CAPE/CIN"},
+    )
+
+
+def _wrap_xarray_3d(pressure: xr.DataArray, values: np.ndarray) -> xr.DataArray:
+    """Preserve xarray metadata for a 3D parcel-profile field."""
+    dims = list(pressure.dims)
+    coords = {}
+    for dim in dims:
+        if dim in pressure.coords:
+            coords[dim] = pressure.coords[dim]
+    return xr.DataArray(
+        values,
+        dims=dims,
+        coords=coords,
+        attrs={"units": "degree_Celsius", "long_name": "parcel temperature"},
+    )
+
+
+def cape_profile(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+):
+    """Compute (cape, cin, lfc_p, el_p) for a single vertical profile.
+
+    Returns four Python floats: CAPE (J/kg), CIN (J/kg, <= 0), LFC
+    pressure (hPa), and EL pressure (hPa). Missing levels return NaN.
+    """
+    p = np.asarray(_as_numpy(pressure), dtype=np.float64)
+    t = np.asarray(_as_numpy(temperature), dtype=np.float64)
+    td = np.asarray(_as_numpy(dewpoint), dtype=np.float64)
+    if p.ndim != 1:
+        raise ValueError(f"pressure must be 1D, got shape {p.shape}")
+    if t.shape != p.shape or td.shape != p.shape:
+        raise ValueError("pressure, temperature, and dewpoint must share a shape")
+    return tuple(
+        float(v)
+        for v in _BACKEND.cape_profile(
+            np.ascontiguousarray(p),
+            np.ascontiguousarray(t),
+            np.ascontiguousarray(td),
+        )
+    )
+
+
+def cape_grid(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+):
+    """Compute (cape, cin, lfc_p, el_p) for a 3D grid of vertical profiles.
+
+    Expects (level, lat, lon) layout; returns four 2D (lat, lon) arrays.
+    """
+    p = np.asarray(_as_numpy(pressure), dtype=np.float64)
+    t = np.asarray(_as_numpy(temperature), dtype=np.float64)
+    td = np.asarray(_as_numpy(dewpoint), dtype=np.float64)
+    if p.ndim != 3:
+        raise ValueError(f"pressure must be 3D, got shape {p.shape}")
+    if t.shape != p.shape or td.shape != p.shape:
+        raise ValueError("pressure, temperature, and dewpoint must share a shape")
+    return tuple(
+        np.asarray(arr, dtype=np.float64)
+        for arr in _BACKEND.cape_grid(
+            np.asfortranarray(p),
+            np.asfortranarray(t),
+            np.asfortranarray(td),
+        )
+    )
+
+
+def parcel_profile(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+) -> np.ndarray:
+    """Compute the surface-based parcel temperature profile (Celsius)."""
+    p = np.asarray(_as_numpy(pressure), dtype=np.float64)
+    t = np.asarray(_as_numpy(temperature), dtype=np.float64)
+    td = np.asarray(_as_numpy(dewpoint), dtype=np.float64)
+    if p.ndim != 1:
+        raise ValueError(f"pressure must be 1D, got shape {p.shape}")
+    if t.shape != p.shape or td.shape != p.shape:
+        raise ValueError("pressure, temperature, and dewpoint must share a shape")
+    return np.asarray(
+        _BACKEND.parcel_profile(
+            np.ascontiguousarray(p),
+            np.ascontiguousarray(t),
+            np.ascontiguousarray(td),
+        ),
+        dtype=np.float64,
+    )
+
+
+def parcel_profile_grid(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+) -> np.ndarray:
+    """Compute parcel temperature profiles for a 3D grid (level, lat, lon)."""
+    p = np.asarray(_as_numpy(pressure), dtype=np.float64)
+    t = np.asarray(_as_numpy(temperature), dtype=np.float64)
+    td = np.asarray(_as_numpy(dewpoint), dtype=np.float64)
+    if p.ndim != 3:
+        raise ValueError(f"pressure must be 3D, got shape {p.shape}")
+    if t.shape != p.shape or td.shape != p.shape:
+        raise ValueError("pressure, temperature, and dewpoint must share a shape")
+    return np.asarray(
+        _BACKEND.parcel_profile_grid(
+            np.asfortranarray(p),
+            np.asfortranarray(t),
+            np.asfortranarray(td),
+        ),
+        dtype=np.float64,
+    )
+
+
+def calculate_cape_cin(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+):
+    """Compute surface-based CAPE and CIN.
+
+    Parameters
+    ----------
+    pressure : np.ndarray or xr.DataArray
+        Pressure in hPa. Either 1D (level,) for a single profile, or
+        3D (level, lat, lon) for a spatial grid.
+    temperature : np.ndarray or xr.DataArray
+        Temperature in Celsius, same shape as ``pressure``.
+    dewpoint : np.ndarray or xr.DataArray
+        Dewpoint temperature in Celsius, same shape as ``pressure``.
+
+    Returns
+    -------
+    tuple of (cape, cin, lfc_p, el_p)
+        For 1D input: four floats (cape and cin in J/kg, lfc_p and el_p
+        in hPa). For 3D input: four 2D arrays (lat, lon), wrapped as
+        ``xr.DataArray`` when the input is an xarray object.
+    """
+    p = _as_numpy(pressure)
+    t = _as_numpy(temperature)
+    td = _as_numpy(dewpoint)
+    is_xarray = hasattr(pressure, "attrs")
+
+    if np.ndim(p) == 1:
+        return cape_profile(p, t, td)
+
+    if np.ndim(p) == 3:
+        out = cape_grid(p, t, td)
+        if is_xarray:
+            out = tuple(_wrap_xarray_result(pressure, arr) for arr in out)
+        return out
+
+    raise ValueError(f"pressure must be 1D or 3D, got shape {np.shape(p)}")
+
+
+def calculate_parcel_profile(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+):
+    """Compute the surface-based parcel temperature profile.
+
+    For 1D input returns a 1D array (Celsius); for 3D input returns a
+    3D array (level, lat, lon), wrapped as ``xr.DataArray`` when the
+    input is an xarray object.
+    """
+    p = _as_numpy(pressure)
+    t = _as_numpy(temperature)
+    td = _as_numpy(dewpoint)
+    is_xarray = hasattr(pressure, "attrs")
+
+    if np.ndim(p) == 1:
+        return parcel_profile(p, t, td)
+
+    if np.ndim(p) == 3:
+        out = parcel_profile_grid(p, t, td)
+        if is_xarray:
+            out = _wrap_xarray_3d(pressure, out)
+        return out
+
+    raise ValueError(f"pressure must be 1D or 3D, got shape {np.shape(p)}")
+
+
+# ---------------------------------------------------------------------------
+# Most unstable parcel
+# ---------------------------------------------------------------------------
+def most_unstable_parcel(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+    depth: float = 300.0,
+):
+    """Find the most unstable parcel (maximum theta-e) within the bottom layer.
+
+    Returns ``(mup_p, mup_t, mup_td, mup_idx)`` for a single profile:
+    pressure (hPa), temperature (Celsius), dewpoint (Celsius) of the most
+    unstable level, and its 0-based index within the cleaned (NaN-free,
+    pressure-decreasing) profile. ``depth`` is the layer depth in hPa,
+    matching metpy's default of 300 hPa.
+    """
+    p = np.asarray(_as_numpy(pressure), dtype=np.float64)
+    t = np.asarray(_as_numpy(temperature), dtype=np.float64)
+    td = np.asarray(_as_numpy(dewpoint), dtype=np.float64)
+    if p.ndim != 1:
+        raise ValueError(f"pressure must be 1D, got shape {p.shape}")
+    if t.shape != p.shape or td.shape != p.shape:
+        raise ValueError("pressure, temperature, and dewpoint must share a shape")
+    return tuple(
+        _BACKEND.most_unstable_parcel(
+            np.ascontiguousarray(p),
+            np.ascontiguousarray(t),
+            np.ascontiguousarray(td),
+            float(depth),
+        )
+    )
+
+
+def most_unstable_parcel_grid(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+    depth: float = 300.0,
+):
+    """Most unstable parcel for every column of a 3D (level, lat, lon) grid.
+
+    Returns four 3D arrays: most-unstable pressure, temperature, dewpoint,
+    and level index (NaN / -1 where no unstable level exists). Only the
+    level selected for each column is populated; other levels are NaN.
+    """
+    p = np.asarray(_as_numpy(pressure), dtype=np.float64)
+    t = np.asarray(_as_numpy(temperature), dtype=np.float64)
+    td = np.asarray(_as_numpy(dewpoint), dtype=np.float64)
+    if p.ndim != 3:
+        raise ValueError(f"pressure must be 3D, got shape {p.shape}")
+    if t.shape != p.shape or td.shape != p.shape:
+        raise ValueError("pressure, temperature, and dewpoint must share a shape")
+    return tuple(
+        np.asarray(arr)
+        for arr in _BACKEND.most_unstable_parcel_grid(
+            np.asfortranarray(p),
+            np.asfortranarray(t),
+            np.asfortranarray(td),
+            float(depth),
+        )
+    )
+
+
+def most_unstable_cape_cin(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+    depth: float = 300.0,
+):
+    """Most unstable CAPE/CIN for a single profile (parcel from the max-theta-e level)."""
+    p = np.asarray(_as_numpy(pressure), dtype=np.float64)
+    t = np.asarray(_as_numpy(temperature), dtype=np.float64)
+    td = np.asarray(_as_numpy(dewpoint), dtype=np.float64)
+    if p.ndim != 1:
+        raise ValueError(f"pressure must be 1D, got shape {p.shape}")
+    if t.shape != p.shape or td.shape != p.shape:
+        raise ValueError("pressure, temperature, and dewpoint must share a shape")
+    return tuple(
+        float(v)
+        for v in _BACKEND.mucape_profile(
+            np.ascontiguousarray(p),
+            np.ascontiguousarray(t),
+            np.ascontiguousarray(td),
+            float(depth),
+        )
+    )
+
+
+def most_unstable_cape_cin_grid(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+    depth: float = 300.0,
+):
+    """Most unstable CAPE/CIN for a 3D grid; returns four 2D (lat, lon) arrays."""
+    p = np.asarray(_as_numpy(pressure), dtype=np.float64)
+    t = np.asarray(_as_numpy(temperature), dtype=np.float64)
+    td = np.asarray(_as_numpy(dewpoint), dtype=np.float64)
+    if p.ndim != 3:
+        raise ValueError(f"pressure must be 3D, got shape {p.shape}")
+    if t.shape != p.shape or td.shape != p.shape:
+        raise ValueError("pressure, temperature, and dewpoint must share a shape")
+    return tuple(
+        np.asarray(arr, dtype=np.float64)
+        for arr in _BACKEND.mucape_grid(
+            np.asfortranarray(p),
+            np.asfortranarray(t),
+            np.asfortranarray(td),
+            float(depth),
+        )
+    )
+
+
+def calculate_most_unstable_parcel(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+    depth: float = 300.0,
+):
+    """Compute the most unstable parcel for 1D or 3D input.
+
+    For 1D input returns ``(mup_p, mup_t, mup_td, mup_idx)`` floats. For 3D
+    input returns four 3D arrays, wrapped as ``xr.DataArray`` when the input
+    is an xarray object.
+    """
+    p = _as_numpy(pressure)
+    t = _as_numpy(temperature)
+    td = _as_numpy(dewpoint)
+    is_xarray = hasattr(pressure, "attrs")
+
+    if np.ndim(p) == 1:
+        return most_unstable_parcel(p, t, td, depth)
+
+    if np.ndim(p) == 3:
+        out = most_unstable_parcel_grid(p, t, td, depth)
+        if is_xarray:
+            out = tuple(_wrap_xarray_3d(pressure, arr) for arr in out[:3]) + (out[3],)
+        return out
+
+    raise ValueError(f"pressure must be 1D or 3D, got shape {np.shape(p)}")
+
+
+def calculate_most_unstable_cape_cin(
+    pressure: Union[np.ndarray, xr.DataArray],
+    temperature: Union[np.ndarray, xr.DataArray],
+    dewpoint: Union[np.ndarray, xr.DataArray],
+    depth: float = 300.0,
+):
+    """Compute most unstable CAPE/CIN for 1D or 3D input.
+
+    For 1D input returns ``(mucape, mucin, mulfc_p, muel_p)`` floats. For 3D
+    input returns four 2D arrays (lat, lon), wrapped as ``xr.DataArray`` when
+    the input is an xarray object.
+    """
+    p = _as_numpy(pressure)
+    t = _as_numpy(temperature)
+    td = _as_numpy(dewpoint)
+    is_xarray = hasattr(pressure, "attrs")
+
+    if np.ndim(p) == 1:
+        return most_unstable_cape_cin(p, t, td, depth)
+
+    if np.ndim(p) == 3:
+        out = most_unstable_cape_cin_grid(p, t, td, depth)
+        if is_xarray:
+            out = tuple(_wrap_xarray_result(pressure, arr) for arr in out)
+        return out
+
+    raise ValueError(f"pressure must be 1D or 3D, got shape {np.shape(p)}")

--- a/src/skyborn/calc/cape/fortran/cape.f90
+++ b/src/skyborn/calc/cape/fortran/cape.f90
@@ -1,0 +1,717 @@
+module cape_mod
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite, ieee_quiet_nan, ieee_value
+  use iso_c_binding, only: c_double
+  implicit none
+  private
+  public :: cape_profile_impl, cape_grid_impl
+  public :: parcel_profile_impl, parcel_profile_grid_impl
+  public :: most_unstable_parcel_impl, most_unstable_parcel_grid_impl
+  public :: mucape_profile_impl, mucape_grid_impl
+
+  ! Physical constants -- same Bolton-based system as the DCAPE backend
+  real(c_double), parameter :: eps = 0.622d0
+  real(c_double), parameter :: rd = 287.05d0
+  real(c_double), parameter :: cp = 1004.0d0
+  real(c_double), parameter :: lv = 2.5d6
+  real(c_double), parameter :: kappa = rd / cp
+
+contains
+
+  !--------------------------------------------------------------------------
+  ! Saturation vapor pressure (hPa) from temperature in Celsius
+  pure real(c_double) function sat_vapor_pressure_hpa(tc) result(es)
+    real(c_double), intent(in) :: tc
+    es = 6.112d0 * exp(17.67d0 * tc / (tc + 243.5d0))
+  end function sat_vapor_pressure_hpa
+
+  ! Saturation vapor pressure (Pa) from temperature in Kelvin
+  pure real(c_double) function sat_vapor_pressure_pa_from_tk(tk) result(es_pa)
+    real(c_double), intent(in) :: tk
+    es_pa = sat_vapor_pressure_hpa(tk - 273.15d0) * 100.0d0
+  end function sat_vapor_pressure_pa_from_tk
+
+  ! Mixing ratio from vapor pressure and total pressure (both Pa)
+  pure real(c_double) function mixing_ratio_from_e_pa(p_pa, e_pa) result(r)
+    real(c_double), intent(in) :: p_pa, e_pa
+    real(c_double) :: e
+    e = max(e_pa, 1.0d-8)
+    e = min(e, 0.99d0 * p_pa)
+    r = eps * e / (p_pa - e)
+  end function mixing_ratio_from_e_pa
+
+  ! Virtual temperature from temperature and mixing ratio
+  pure real(c_double) function virtual_temp_k(tk, mixing_ratio) result(tv)
+    real(c_double), intent(in) :: tk, mixing_ratio
+    tv = tk * (mixing_ratio + eps) / (eps * (1.0d0 + mixing_ratio))
+  end function virtual_temp_k
+
+  ! Moist pseudo-adiabat dT/dp (Bakhshaii2013 formulation, same as metpy)
+  pure real(c_double) function dt_dp_moist(p_pa, t_k) result(dt_dp)
+    real(c_double), intent(in) :: p_pa, t_k
+    real(c_double) :: es, rs, num, den
+    es = sat_vapor_pressure_pa_from_tk(t_k)
+    rs = mixing_ratio_from_e_pa(p_pa, es)
+    num = rd * t_k + lv * rs
+    den = cp + (lv * lv * rs * eps) / (rd * t_k * t_k)
+    dt_dp = (num / den) / p_pa
+  end function dt_dp_moist
+
+  ! Fixed-step RK4 integration of the moist adiabat
+  real(c_double) function rk4_integrate_moist_t(p_start_pa, t_start_k, p_target_pa) result(t_out)
+    real(c_double), intent(in) :: p_start_pa, t_start_k, p_target_pa
+    real(c_double) :: dp_total, h, p, t, k1, k2, k3, k4
+    integer :: nstep, istep
+
+    dp_total = p_target_pa - p_start_pa
+    if (abs(dp_total) < 1.0d-9) then
+      t_out = t_start_k
+      return
+    end if
+
+    nstep = int(abs(dp_total) / 200.0d0) + 1
+    h = dp_total / real(nstep, c_double)
+    p = p_start_pa
+    t = t_start_k
+    do istep = 1, nstep
+      k1 = dt_dp_moist(p, t)
+      k2 = dt_dp_moist(p + 0.5d0 * h, t + 0.5d0 * h * k1)
+      k3 = dt_dp_moist(p + 0.5d0 * h, t + 0.5d0 * h * k2)
+      k4 = dt_dp_moist(p + h, t + h * k3)
+      t = t + (h / 6.0d0) * (k1 + 2.0d0 * k2 + 2.0d0 * k3 + k4)
+      p = p + h
+    end do
+    t_out = t
+  end function rk4_integrate_moist_t
+
+  ! Bolton-approximation LCL
+  subroutine lcl_bolton(p_hpa, tc, tdc, plcl_hpa, tlcl_k)
+    real(c_double), intent(in) :: p_hpa, tc, tdc
+    real(c_double), intent(out) :: plcl_hpa, tlcl_k
+    real(c_double) :: t, td
+    t = tc + 273.15d0
+    td = max(tdc + 273.15d0, 173.15d0)
+    tlcl_k = 56.0d0 + 1.0d0 / (1.0d0 / (td - 56.0d0) + log(t / td) / 800.0d0)
+    plcl_hpa = p_hpa * (tlcl_k / t) ** (1.0d0 / kappa)
+  end subroutine lcl_bolton
+
+  !--------------------------------------------------------------------------
+  ! Drop non-finite levels and sort pressure in decreasing order (sfc first)
+  subroutine clean_and_sort(nlev, p_in, t_in, td_in, m, p, t, td)
+    integer, intent(in) :: nlev
+    real(c_double), intent(in) :: p_in(nlev), t_in(nlev), td_in(nlev)
+    integer, intent(out) :: m
+    real(c_double), intent(out) :: p(:), t(:), td(:)
+    integer :: k, k2
+
+    m = 0
+    do k = 1, nlev
+      if (ieee_is_finite(p_in(k)) .and. ieee_is_finite(t_in(k)) .and. &
+          ieee_is_finite(td_in(k))) then
+        m = m + 1
+        p(m) = p_in(k)
+        t(m) = t_in(k)
+        td(m) = td_in(k)
+      end if
+    end do
+
+    if (m > 1) then
+      if (p(1) < p(m)) then
+        do k = 1, m / 2
+          k2 = m + 1 - k
+          call swap_real(p(k), p(k2))
+          call swap_real(t(k), t(k2))
+          call swap_real(td(k), td(k2))
+        end do
+      end if
+    end if
+  end subroutine clean_and_sort
+
+  !--------------------------------------------------------------------------
+  ! Parcel temperature profile (K) at each pressure level.
+  ! Dry adiabatic below the LCL, moist pseudo-adiabatic (RK4) above.
+  ! The moist segment is integrated sequentially level by level (O(n)
+  ! rather than re-integrating from the LCL for every level).
+  subroutine parcel_temp_profile(m, p_hpa, t_c, td_c, plcl_hpa, tlcl_k, t_par_k)
+    integer, intent(in) :: m
+    real(c_double), intent(in) :: p_hpa(m), t_c(m), td_c(m)
+    real(c_double), intent(in) :: plcl_hpa, tlcl_k
+    real(c_double), intent(out) :: t_par_k(m)
+    real(c_double) :: t0_k, p0_hpa
+    integer :: k, k2
+
+    t0_k = t_c(1) + 273.15d0
+    p0_hpa = p_hpa(1)
+
+    ! Dry adiabat below the LCL (potential temperature conserved)
+    k = 1
+    do while (k <= m .and. p_hpa(k) >= plcl_hpa)
+      t_par_k(k) = t0_k * (p_hpa(k) / p0_hpa) ** kappa
+      k = k + 1
+    end do
+
+    ! All levels below the LCL? Nothing left to do.
+    if (k > m) return
+
+    ! First moist level: integrate once from the LCL
+    t_par_k(k) = rk4_integrate_moist_t(plcl_hpa * 100.0d0, tlcl_k, &
+                                       p_hpa(k) * 100.0d0)
+    ! Remaining moist levels: integrate sequentially from the previous level
+    do k2 = k + 1, m
+      t_par_k(k2) = rk4_integrate_moist_t(p_hpa(k2 - 1) * 100.0d0, &
+                                          t_par_k(k2 - 1), &
+                                          p_hpa(k2) * 100.0d0)
+    end do
+  end subroutine parcel_temp_profile
+
+  !--------------------------------------------------------------------------
+  ! Zero crossings of y along log(p). Fills p_ext / y_ext (sorted in
+  ! decreasing pressure), n_ext points. Crossing direction:
+  !   dir = 1 : y goes from negative to positive
+  !   dir = -1: y goes from positive to negative
+  !   dir = 0 : all crossings
+  subroutine append_zero_crossings(m, p, y, n_ext, p_ext, y_ext)
+    integer, intent(in) :: m
+    real(c_double), intent(in) :: p(m), y(m)
+    integer, intent(out) :: n_ext
+    real(c_double), intent(out) :: p_ext(:), y_ext(:)
+    real(c_double) :: lnp0, lnp1, w, p_zero
+    integer :: k
+
+    n_ext = 0
+    ! Start from the surface point (y(1) == 0 for a surface parcel)
+    if (m >= 1) then
+      n_ext = 1
+      p_ext(1) = p(1)
+      y_ext(1) = y(1)
+    end if
+
+    ! Find crossings between levels k-1 and k (metpy uses x[1:], skipping
+    ! the surface point, since the surface parcel matches the environment)
+    do k = 2, m
+      ! sign convention: treat exact zeros as positive (as metpy does)
+      if ((y(k - 1) < 0.0d0 .and. y(k) > 0.0d0) .or. &
+          (y(k - 1) < 0.0d0 .and. abs(y(k)) < 1.0d-12) .or. &
+          (abs(y(k - 1)) < 1.0d-12 .and. y(k) < 0.0d0)) then
+        ! log-pressure linear interpolation to y = 0
+        lnp0 = log(p(k - 1))
+        lnp1 = log(p(k))
+        if (abs(y(k) - y(k - 1)) > 1.0d-12) then
+          w = (0.0d0 - y(k - 1)) / (y(k) - y(k - 1))
+          p_zero = exp(lnp0 + w * (lnp1 - lnp0))
+        else
+          p_zero = p(k)
+        end if
+        ! avoid duplicate pressure values
+        if (abs(p_zero - p(k)) > 1.0d-6 .and. abs(p_zero - p(k - 1)) > 1.0d-6) then
+          n_ext = n_ext + 1
+          p_ext(n_ext) = p_zero
+          y_ext(n_ext) = 0.0d0
+        end if
+      else if ((y(k - 1) > 0.0d0 .and. y(k) < 0.0d0) .or. &
+               (abs(y(k - 1)) < 1.0d-12 .and. y(k) > 0.0d0)) then
+        lnp0 = log(p(k - 1))
+        lnp1 = log(p(k))
+        if (abs(y(k) - y(k - 1)) > 1.0d-12) then
+          w = (0.0d0 - y(k - 1)) / (y(k) - y(k - 1))
+          p_zero = exp(lnp0 + w * (lnp1 - lnp0))
+        else
+          p_zero = p(k)
+        end if
+        if (abs(p_zero - p(k)) > 1.0d-6 .and. abs(p_zero - p(k - 1)) > 1.0d-6) then
+          n_ext = n_ext + 1
+          p_ext(n_ext) = p_zero
+          y_ext(n_ext) = 0.0d0
+        end if
+      end if
+      n_ext = n_ext + 1
+      p_ext(n_ext) = p(k)
+      y_ext(n_ext) = y(k)
+    end do
+  end subroutine append_zero_crossings
+
+  ! Collect crossings of a given direction. Returns count and pressures.
+  subroutine collect_crossings(m, p, y, direction, n_cross, p_cross)
+    integer, intent(in) :: m
+    real(c_double), intent(in) :: p(m), y(m)
+    integer, intent(in) :: direction   ! 1: increasing (neg->pos), -1: decreasing
+    integer, intent(out) :: n_cross
+    real(c_double), intent(out) :: p_cross(:)
+    real(c_double) :: lnp0, lnp1, w, p_zero
+    integer :: k
+
+    n_cross = 0
+    do k = 2, m
+      if (direction > 0) then
+        if ((y(k - 1) < 0.0d0 .and. y(k) > 0.0d0) .or. &
+            (y(k - 1) < 0.0d0 .and. abs(y(k)) < 1.0d-12)) then
+          lnp0 = log(p(k - 1))
+          lnp1 = log(p(k))
+          if (abs(y(k) - y(k - 1)) > 1.0d-12) then
+            w = (0.0d0 - y(k - 1)) / (y(k) - y(k - 1))
+            p_zero = exp(lnp0 + w * (lnp1 - lnp0))
+          else
+            p_zero = p(k)
+          end if
+          n_cross = n_cross + 1
+          p_cross(n_cross) = p_zero
+        end if
+      else
+        if ((y(k - 1) > 0.0d0 .and. y(k) < 0.0d0) .or. &
+            (abs(y(k - 1)) < 1.0d-12 .and. y(k) < 0.0d0)) then
+          lnp0 = log(p(k - 1))
+          lnp1 = log(p(k))
+          if (abs(y(k) - y(k - 1)) > 1.0d-12) then
+            w = (0.0d0 - y(k - 1)) / (y(k) - y(k - 1))
+            p_zero = exp(lnp0 + w * (lnp1 - lnp0))
+          else
+            p_zero = p(k)
+          end if
+          n_cross = n_cross + 1
+          p_cross(n_cross) = p_zero
+        end if
+      end if
+    end do
+  end subroutine collect_crossings
+
+  !--------------------------------------------------------------------------
+  ! Single-profile CAPE/CIN (surface-based parcel, metpy-compatible
+  ! which_lfc='bottom', which_el='top' semantics).
+  subroutine cape_profile_impl(nlev, pressure_hpa, temperature_c, dewpoint_c, &
+                               cape, cin, lfc_p_hpa, el_p_hpa)
+    integer, intent(in) :: nlev
+    real(c_double), intent(in) :: pressure_hpa(nlev)
+    real(c_double), intent(in) :: temperature_c(nlev)
+    real(c_double), intent(in) :: dewpoint_c(nlev)
+    real(c_double), intent(out) :: cape, cin, lfc_p_hpa, el_p_hpa
+
+    real(c_double), allocatable :: p(:), t(:), td(:)
+    real(c_double), allocatable :: t_par_k(:), r_par(:), r_env(:)
+    real(c_double), allocatable :: tv_par(:), tv_env(:), y(:)
+    real(c_double), allocatable :: p_ext(:), y_ext(:)
+    real(c_double), allocatable :: p_lfc_cross(:), p_el_cross(:)
+
+    real(c_double) :: t0_c, td0_c, p0_hpa
+    real(c_double) :: plcl_actual, tlcl_k, plcl_lfc, tv1_c
+    real(c_double) :: lfc, el_p, rtol, atol
+    real(c_double) :: es0_pa, es_par_pa, es_env_pa
+    real(c_double) :: integral, dlnp
+    integer :: m, k, n_ext, n_lfc, n_el, i
+    logical :: no_lfc
+
+    cape = ieee_value(0.0d0, ieee_quiet_nan)
+    cin = ieee_value(0.0d0, ieee_quiet_nan)
+    lfc_p_hpa = ieee_value(0.0d0, ieee_quiet_nan)
+    el_p_hpa = ieee_value(0.0d0, ieee_quiet_nan)
+
+    allocate(p(nlev), t(nlev), td(nlev))
+    call clean_and_sort(nlev, pressure_hpa, temperature_c, dewpoint_c, m, p, t, td)
+
+    if (m < 2) then
+      deallocate(p, t, td)
+      return
+    end if
+
+    allocate(t_par_k(m), r_par(m), r_env(m), tv_par(m), tv_env(m), y(m))
+
+    ! Surface parcel state
+    t0_c = t(1)
+    td0_c = td(1)
+    p0_hpa = p(1)
+
+    ! LCL from actual temperature (used for parcel mixing-ratio split)
+    call lcl_bolton(p0_hpa, t0_c, td0_c, plcl_actual, tlcl_k)
+
+    ! Parcel temperature profile
+    call parcel_temp_profile(m, p, t, td, plcl_actual, tlcl_k, t_par_k)
+
+    ! Mixing ratios and virtual temperatures
+    es0_pa = sat_vapor_pressure_hpa(td0_c) * 100.0d0
+    do k = 1, m
+      if (p(k) >= plcl_actual) then
+        ! Below LCL: parcel mixing ratio fixed at surface saturated value
+        r_par(k) = mixing_ratio_from_e_pa(p0_hpa * 100.0d0, es0_pa)
+      else
+        es_par_pa = sat_vapor_pressure_pa_from_tk(t_par_k(k))
+        r_par(k) = mixing_ratio_from_e_pa(p(k) * 100.0d0, es_par_pa)
+      end if
+      es_env_pa = sat_vapor_pressure_hpa(td(k)) * 100.0d0
+      r_env(k) = mixing_ratio_from_e_pa(p(k) * 100.0d0, es_env_pa)
+      tv_par(k) = virtual_temp_k(t_par_k(k), r_par(k))
+      tv_env(k) = virtual_temp_k(t(k) + 273.15d0, r_env(k))
+      y(k) = tv_par(k) - tv_env(k)
+    end do
+
+    ! LCL in virtual temperature, used by metpy's lfc()/el() as the
+    ! lower bound for physically meaningful intersections
+    tv1_c = tv_par(1) - 273.15d0
+    call lcl_bolton(p0_hpa, tv1_c, td0_c, plcl_lfc, tlcl_k)
+
+    ! ---- Level of free convection (metpy which='bottom') ----
+    no_lfc = .false.
+    lfc = ieee_value(0.0d0, ieee_quiet_nan)
+    allocate(p_lfc_cross(m), p_el_cross(m))
+    call collect_crossings(m, p, y, 1, n_lfc, p_lfc_cross)
+    if (n_lfc == 0) then
+      ! Any positive area above the LCL?
+      do k = 1, m
+        if (p(k) < plcl_lfc .and. y(k) > 0.0d0) exit
+      end do
+      if (k > m) then
+        no_lfc = .true.   ! no positive buoyancy above LCL: no LFC
+      else
+        lfc = plcl_lfc    ! LFC = LCL
+      end if
+    else
+      ! Is any crossing above the LCL (pressure < LCL)?
+      do i = 1, n_lfc
+        if (p_lfc_cross(i) < plcl_lfc) exit
+      end do
+      if (i > n_lfc) then
+        ! All crossings below the LCL. Check whether an EL also exists
+        ! below the LCL: if so, no LFC; otherwise LFC = LCL.
+        call collect_crossings(m, p, y, -1, n_el, p_el_cross)
+        if (n_el > 0) then
+          if (minval(p_el_cross) > plcl_lfc) then
+            no_lfc = .true.
+          else
+            lfc = plcl_lfc
+          end if
+        else
+          lfc = plcl_lfc
+        end if
+      else
+        ! First (highest-pressure) crossing above the LCL
+        lfc = p_lfc_cross(i)
+      end if
+    end if
+
+    if (no_lfc) then
+      cape = 0.0d0
+      cin = 0.0d0
+      lfc_p_hpa = ieee_value(0.0d0, ieee_quiet_nan)
+      el_p_hpa = ieee_value(0.0d0, ieee_quiet_nan)
+      deallocate(p, t, td, t_par_k, r_par, r_env, tv_par, tv_env, y, &
+                 p_lfc_cross, p_el_cross)
+      return
+    end if
+
+    ! ---- Equilibrium level (metpy which='top') ----
+    el_p = ieee_value(0.0d0, ieee_quiet_nan)
+    if (y(m) > 0.0d0) then
+      ! Parcel warmer than environment at the top of the sounding
+      el_p = p(m)
+    else
+      call collect_crossings(m, p, y, -1, n_el, p_el_cross)
+      if (n_el > 0) then
+        ! ELs below the LCL; take the lowest pressure one (which='top')
+        do i = n_el, 1, -1
+          if (p_el_cross(i) < plcl_lfc) exit
+        end do
+        if (i >= 1) then
+          el_p = p_el_cross(i)
+        else
+          el_p = p(m)
+        end if
+      else
+        el_p = p(m)
+      end if
+    end if
+
+    ! ---- Build extended series with appended zero crossings ----
+    allocate(p_ext(2 * m + 2), y_ext(2 * m + 2))
+    call append_zero_crossings(m, p, y, n_ext, p_ext, y_ext)
+
+    ! ---- Integrate (pressure decreasing order) ----
+    rtol = 1.0d-5
+    atol = 1.0d-8
+
+    ! CIN: from surface to LFC.  cin = -Rd * sum 0.5*(y_i+y_{i+1})*dlnp
+    integral = 0.0d0
+    do i = 1, n_ext - 1
+      ! segment [p_ext(i), p_ext(i+1)], both >= LFC (isclose semantics)
+      if ((p_ext(i) >= lfc .or. abs(p_ext(i) - lfc) <= atol + rtol * abs(lfc)) .and. &
+          (p_ext(i + 1) >= lfc .or. abs(p_ext(i + 1) - lfc) <= atol + rtol * abs(lfc))) then
+        dlnp = log(p_ext(i + 1)) - log(p_ext(i))
+        integral = integral + 0.5d0 * (y_ext(i) + y_ext(i + 1)) * dlnp
+      end if
+    end do
+    cin = -rd * integral
+    if (cin > 0.0d0) cin = 0.0d0
+
+    ! CAPE: from LFC to EL
+    integral = 0.0d0
+    do i = 1, n_ext - 1
+      if ((p_ext(i) <= lfc .or. abs(p_ext(i) - lfc) <= atol + rtol * abs(lfc)) .and. &
+          (p_ext(i) >= el_p .or. abs(p_ext(i) - el_p) <= atol + rtol * abs(el_p)) .and. &
+          (p_ext(i + 1) <= lfc .or. abs(p_ext(i + 1) - lfc) <= atol + rtol * abs(lfc)) .and. &
+          (p_ext(i + 1) >= el_p .or. abs(p_ext(i + 1) - el_p) <= atol + rtol * abs(el_p))) then
+        dlnp = log(p_ext(i + 1)) - log(p_ext(i))
+        integral = integral + 0.5d0 * (y_ext(i) + y_ext(i + 1)) * dlnp
+      end if
+    end do
+    cape = -rd * integral
+    if (.not. ieee_is_finite(cape)) cape = 0.0d0
+    if (.not. ieee_is_finite(cin)) cin = 0.0d0
+
+    lfc_p_hpa = lfc
+    el_p_hpa = el_p
+
+    deallocate(p, t, td, t_par_k, r_par, r_env, tv_par, tv_env, y, &
+               p_ext, y_ext, p_lfc_cross, p_el_cross)
+  end subroutine cape_profile_impl
+
+  !--------------------------------------------------------------------------
+  ! Single-profile parcel temperature (Celsius), for reuse by callers.
+  subroutine parcel_profile_impl(nlev, pressure_hpa, temperature_c, dewpoint_c, t_par_c)
+    integer, intent(in) :: nlev
+    real(c_double), intent(in) :: pressure_hpa(nlev)
+    real(c_double), intent(in) :: temperature_c(nlev)
+    real(c_double), intent(in) :: dewpoint_c(nlev)
+    real(c_double), intent(out) :: t_par_c(nlev)
+
+    real(c_double), allocatable :: p(:), t(:), td(:), t_par_k(:)
+    real(c_double) :: plcl_hpa, tlcl_k
+    integer :: m, k, j
+
+    t_par_c = ieee_value(0.0d0, ieee_quiet_nan)
+    allocate(p(nlev), t(nlev), td(nlev), t_par_k(nlev))
+    call clean_and_sort(nlev, pressure_hpa, temperature_c, dewpoint_c, m, p, t, td)
+    if (m < 2) then
+      deallocate(p, t, td, t_par_k)
+      return
+    end if
+
+    call lcl_bolton(p(1), t(1), td(1), plcl_hpa, tlcl_k)
+    call parcel_temp_profile(m, p, t, td, plcl_hpa, tlcl_k, t_par_k)
+
+    ! Map back to the original (cleaned) level ordering
+    do k = 1, nlev
+      do j = 1, m
+        if (abs(pressure_hpa(k) - p(j)) < 1.0d-9 .and. &
+            abs(temperature_c(k) - t(j)) < 1.0d-9 .and. &
+            abs(dewpoint_c(k) - td(j)) < 1.0d-9) then
+          t_par_c(k) = t_par_k(j) - 273.15d0
+          exit
+        end if
+      end do
+    end do
+    deallocate(p, t, td, t_par_k)
+  end subroutine parcel_profile_impl
+
+  !--------------------------------------------------------------------------
+  ! Grid kernels: loop over horizontal profiles (column-major friendly)
+  subroutine parcel_profile_grid_impl(nlev, nlat, nlon, p3, t3, td3, out)
+    integer, intent(in) :: nlev, nlat, nlon
+    real(c_double), intent(in) :: p3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: t3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: td3(nlev, nlat, nlon)
+    real(c_double), intent(out) :: out(nlev, nlat, nlon)
+    integer :: j, i
+    do i = 1, nlon
+      do j = 1, nlat
+        call parcel_profile_impl(nlev, p3(:, j, i), t3(:, j, i), td3(:, j, i), out(:, j, i))
+      end do
+    end do
+  end subroutine parcel_profile_grid_impl
+
+  subroutine cape_grid_impl(nlev, nlat, nlon, p3, t3, td3, cape2, cin2, lfc2, el2)
+    integer, intent(in) :: nlev, nlat, nlon
+    real(c_double), intent(in) :: p3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: t3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: td3(nlev, nlat, nlon)
+    real(c_double), intent(out) :: cape2(nlat, nlon)
+    real(c_double), intent(out) :: cin2(nlat, nlon)
+    real(c_double), intent(out) :: lfc2(nlat, nlon)
+    real(c_double), intent(out) :: el2(nlat, nlon)
+    integer :: j, i
+    do i = 1, nlon
+      do j = 1, nlat
+        call cape_profile_impl(nlev, p3(:, j, i), t3(:, j, i), td3(:, j, i), &
+                               cape2(j, i), cin2(j, i), lfc2(j, i), el2(j, i))
+      end do
+    end do
+  end subroutine cape_grid_impl
+
+  subroutine swap_real(a, b)
+    real(c_double), intent(inout) :: a, b
+    real(c_double) :: tmp
+    tmp = a
+    a = b
+    b = tmp
+  end subroutine swap_real
+
+  !--------------------------------------------------------------------------
+  ! Bolton 1980 equivalent potential temperature (K). Identical to metpy's
+  ! equivalent_potential_temperature and to the DCAPE backend's formulation.
+  pure real(c_double) function thetae_bolton_like_metpy(p_hpa, tc, tdc) result(thetae)
+    real(c_double), intent(in) :: p_hpa, tc, tdc
+    real(c_double) :: t, td, p_pa, e_pa, r, t_l, th_l
+    t = tc + 273.15d0
+    td = max(tdc + 273.15d0, 173.15d0)
+    p_pa = p_hpa * 100.0d0
+    e_pa = sat_vapor_pressure_hpa(tdc) * 100.0d0
+    r = mixing_ratio_from_e_pa(p_pa, e_pa)
+    t_l = 56.0d0 + 1.0d0 / (1.0d0 / (td - 56.0d0) + log(t / td) / 800.0d0)
+    th_l = t * (100000.0d0 / (p_pa - e_pa)) ** kappa * (t / t_l) ** (0.28d0 * r)
+    thetae = th_l * exp(r * (1.0d0 + 0.448d0 * r) * (3036.0d0 / t_l - 1.78d0))
+  end function thetae_bolton_like_metpy
+
+  !--------------------------------------------------------------------------
+  ! Search the layer [p(1)-depth, p(1)] for the level with maximum theta-e.
+  ! Operates on a cleaned, pressure-decreasing profile. Returns the level
+  ! index k0 (1-based within the cleaned array) or -1 if none qualify.
+  subroutine most_unstable_search(m, p, t, td, depth_hpa, k0)
+    integer, intent(in) :: m
+    real(c_double), intent(in) :: p(m), t(m), td(m)
+    real(c_double), intent(in) :: depth_hpa
+    integer, intent(out) :: k0
+    real(c_double) :: bottom_p, top_p, te_max, te
+    integer :: k
+
+    k0 = -1
+    if (m < 1) return
+    bottom_p = p(1)
+    top_p = bottom_p - depth_hpa
+    te_max = -huge(0.0d0)
+    do k = 1, m
+      if (p(k) <= bottom_p .and. p(k) >= top_p - 1.0d-9) then
+        te = thetae_bolton_like_metpy(p(k), t(k), td(k))
+        if (te > te_max) then
+          te_max = te
+          k0 = k
+        end if
+      end if
+    end do
+  end subroutine most_unstable_search
+
+  !--------------------------------------------------------------------------
+  ! Most unstable parcel: pressure / temperature / dewpoint of the level with
+  ! the largest theta-e inside the bottom-`depth` layer (metpy default 300 hPa).
+  subroutine most_unstable_parcel_impl(nlev, pressure_hpa, temperature_c, dewpoint_c, &
+                                       depth_hpa, mup_p, mup_t, mup_td, mup_idx)
+    integer, intent(in) :: nlev
+    real(c_double), intent(in) :: pressure_hpa(nlev)
+    real(c_double), intent(in) :: temperature_c(nlev)
+    real(c_double), intent(in) :: dewpoint_c(nlev)
+    real(c_double), intent(in) :: depth_hpa
+    real(c_double), intent(out) :: mup_p, mup_t, mup_td
+    integer, intent(out) :: mup_idx
+
+    real(c_double), allocatable :: p(:), t(:), td(:)
+    integer :: m, k0
+
+    mup_p = ieee_value(0.0d0, ieee_quiet_nan)
+    mup_t = ieee_value(0.0d0, ieee_quiet_nan)
+    mup_td = ieee_value(0.0d0, ieee_quiet_nan)
+    mup_idx = -1
+
+    allocate(p(nlev), t(nlev), td(nlev))
+    call clean_and_sort(nlev, pressure_hpa, temperature_c, dewpoint_c, m, p, t, td)
+    if (m < 1) then
+      deallocate(p, t, td)
+      return
+    end if
+    call most_unstable_search(m, p, t, td, depth_hpa, k0)
+    if (k0 >= 1) then
+      mup_p = p(k0)
+      mup_t = t(k0)
+      mup_td = td(k0)
+      mup_idx = k0 - 1   ! 0-based index within the cleaned profile
+    end if
+    deallocate(p, t, td)
+  end subroutine most_unstable_parcel_impl
+
+  !--------------------------------------------------------------------------
+  ! Most unstable CAPE/CIN: parcel lifted from the most unstable level.
+  subroutine mucape_profile_impl(nlev, pressure_hpa, temperature_c, dewpoint_c, &
+                                 depth_hpa, cape, cin, lfc_p, el_p)
+    integer, intent(in) :: nlev
+    real(c_double), intent(in) :: pressure_hpa(nlev)
+    real(c_double), intent(in) :: temperature_c(nlev)
+    real(c_double), intent(in) :: dewpoint_c(nlev)
+    real(c_double), intent(in) :: depth_hpa
+    real(c_double), intent(out) :: cape, cin, lfc_p, el_p
+
+    real(c_double), allocatable :: p(:), t(:), td(:)
+    real(c_double), allocatable :: sp(:), st(:), std(:)
+    integer :: m, k0
+
+    cape = ieee_value(0.0d0, ieee_quiet_nan)
+    cin = ieee_value(0.0d0, ieee_quiet_nan)
+    lfc_p = ieee_value(0.0d0, ieee_quiet_nan)
+    el_p = ieee_value(0.0d0, ieee_quiet_nan)
+
+    allocate(p(nlev), t(nlev), td(nlev))
+    call clean_and_sort(nlev, pressure_hpa, temperature_c, dewpoint_c, m, p, t, td)
+    if (m < 2) then
+      deallocate(p, t, td)
+      return
+    end if
+    call most_unstable_search(m, p, t, td, depth_hpa, k0)
+    if (k0 < 1) then
+      deallocate(p, t, td)
+      return
+    end if
+
+    allocate(sp(m - k0 + 1), st(m - k0 + 1), std(m - k0 + 1))
+    sp(1:) = p(k0:m)
+    st(1:) = t(k0:m)
+    std(1:) = td(k0:m)
+    call cape_profile_impl(m - k0 + 1, sp, st, std, cape, cin, lfc_p, el_p)
+    deallocate(p, t, td, sp, st, std)
+  end subroutine mucape_profile_impl
+
+  !--------------------------------------------------------------------------
+  ! Grid versions
+  subroutine most_unstable_parcel_grid_impl(nlev, nlat, nlon, p3, t3, td3, depth, &
+                                            out_p3, out_t3, out_td3, out_idx3)
+    integer, intent(in) :: nlev, nlat, nlon
+    real(c_double), intent(in) :: p3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: t3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: td3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: depth
+    real(c_double), intent(out) :: out_p3(nlev, nlat, nlon)
+    real(c_double), intent(out) :: out_t3(nlev, nlat, nlon)
+    real(c_double), intent(out) :: out_td3(nlev, nlat, nlon)
+    integer, intent(out) :: out_idx3(nlev, nlat, nlon)
+    real(c_double) :: mp, mt, mtd
+    integer :: mi, j, i
+
+    out_p3 = ieee_value(0.0d0, ieee_quiet_nan)
+    out_t3 = ieee_value(0.0d0, ieee_quiet_nan)
+    out_td3 = ieee_value(0.0d0, ieee_quiet_nan)
+    out_idx3 = -1
+    do i = 1, nlon
+      do j = 1, nlat
+        call most_unstable_parcel_impl(nlev, p3(:, j, i), t3(:, j, i), td3(:, j, i), &
+                                       depth, mp, mt, mtd, mi)
+        if (mi >= 0) then
+          out_p3(mi + 1, j, i) = mp
+          out_t3(mi + 1, j, i) = mt
+          out_td3(mi + 1, j, i) = mtd
+          out_idx3(mi + 1, j, i) = mi
+        end if
+      end do
+    end do
+  end subroutine most_unstable_parcel_grid_impl
+
+  subroutine mucape_grid_impl(nlev, nlat, nlon, p3, t3, td3, depth, cape2, cin2, lfc2, el2)
+    integer, intent(in) :: nlev, nlat, nlon
+    real(c_double), intent(in) :: p3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: t3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: td3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: depth
+    real(c_double), intent(out) :: cape2(nlat, nlon)
+    real(c_double), intent(out) :: cin2(nlat, nlon)
+    real(c_double), intent(out) :: lfc2(nlat, nlon)
+    real(c_double), intent(out) :: el2(nlat, nlon)
+    integer :: j, i
+    do i = 1, nlon
+      do j = 1, nlat
+        call mucape_profile_impl(nlev, p3(:, j, i), t3(:, j, i), td3(:, j, i), &
+                                 depth, cape2(j, i), cin2(j, i), lfc2(j, i), el2(j, i))
+      end do
+    end do
+  end subroutine mucape_grid_impl
+
+end module cape_mod

--- a/src/skyborn/calc/cape/fortran/cape_bindings.f90
+++ b/src/skyborn/calc/cape/fortran/cape_bindings.f90
@@ -1,0 +1,109 @@
+subroutine cape_profile_c(nlev, pressure_hpa, temperature_c, dewpoint_c, cape, cin, lfc_p, el_p) bind(C, name="cape_profile_c")
+  use iso_c_binding, only: c_double, c_int
+  use cape_mod, only: cape_profile_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev
+  real(c_double), intent(in) :: pressure_hpa(nlev)
+  real(c_double), intent(in) :: temperature_c(nlev)
+  real(c_double), intent(in) :: dewpoint_c(nlev)
+  real(c_double), intent(out) :: cape, cin, lfc_p, el_p
+  call cape_profile_impl(int(nlev), pressure_hpa, temperature_c, dewpoint_c, cape, cin, lfc_p, el_p)
+end subroutine cape_profile_c
+
+subroutine cape_grid_c(nlev, nlat, nlon, pressure_3d, t_3d, td_3d, cape2, cin2, lfc2, el2) bind(C, name="cape_grid_c")
+  use iso_c_binding, only: c_double, c_int
+  use cape_mod, only: cape_grid_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev, nlat, nlon
+  real(c_double), intent(in) :: pressure_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: t_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: td_3d(nlev, nlat, nlon)
+  real(c_double), intent(out) :: cape2(nlat, nlon)
+  real(c_double), intent(out) :: cin2(nlat, nlon)
+  real(c_double), intent(out) :: lfc2(nlat, nlon)
+  real(c_double), intent(out) :: el2(nlat, nlon)
+  call cape_grid_impl(int(nlev), int(nlat), int(nlon), pressure_3d, t_3d, td_3d, cape2, cin2, lfc2, el2)
+end subroutine cape_grid_c
+
+subroutine parcel_profile_c(nlev, pressure_hpa, temperature_c, dewpoint_c, t_par_c) bind(C, name="parcel_profile_c")
+  use iso_c_binding, only: c_double, c_int
+  use cape_mod, only: parcel_profile_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev
+  real(c_double), intent(in) :: pressure_hpa(nlev)
+  real(c_double), intent(in) :: temperature_c(nlev)
+  real(c_double), intent(in) :: dewpoint_c(nlev)
+  real(c_double), intent(out) :: t_par_c(nlev)
+  call parcel_profile_impl(int(nlev), pressure_hpa, temperature_c, dewpoint_c, t_par_c)
+end subroutine parcel_profile_c
+
+subroutine parcel_profile_grid_c(nlev, nlat, nlon, pressure_3d, t_3d, td_3d, out_3d) bind(C, name="parcel_profile_grid_c")
+  use iso_c_binding, only: c_double, c_int
+  use cape_mod, only: parcel_profile_grid_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev, nlat, nlon
+  real(c_double), intent(in) :: pressure_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: t_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: td_3d(nlev, nlat, nlon)
+  real(c_double), intent(out) :: out_3d(nlev, nlat, nlon)
+  call parcel_profile_grid_impl(int(nlev), int(nlat), int(nlon), pressure_3d, t_3d, td_3d, out_3d)
+end subroutine parcel_profile_grid_c
+
+subroutine most_unstable_parcel_c(nlev, pressure_hpa, temperature_c, dewpoint_c, depth_hpa, mup_p, mup_t, mup_td, mup_idx) bind(C, name="most_unstable_parcel_c")
+  use iso_c_binding, only: c_double, c_int
+  use cape_mod, only: most_unstable_parcel_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev
+  real(c_double), intent(in) :: pressure_hpa(nlev)
+  real(c_double), intent(in) :: temperature_c(nlev)
+  real(c_double), intent(in) :: dewpoint_c(nlev)
+  real(c_double), value, intent(in) :: depth_hpa
+  real(c_double), intent(out) :: mup_p, mup_t, mup_td
+  integer(c_int), intent(out) :: mup_idx
+  call most_unstable_parcel_impl(int(nlev), pressure_hpa, temperature_c, dewpoint_c, depth_hpa, mup_p, mup_t, mup_td, mup_idx)
+end subroutine most_unstable_parcel_c
+
+subroutine most_unstable_parcel_grid_c(nlev, nlat, nlon, pressure_3d, t_3d, td_3d, depth_hpa, out_p3, out_t3, out_td3, out_idx3) bind(C, name="most_unstable_parcel_grid_c")
+  use iso_c_binding, only: c_double, c_int
+  use cape_mod, only: most_unstable_parcel_grid_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev, nlat, nlon
+  real(c_double), intent(in) :: pressure_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: t_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: td_3d(nlev, nlat, nlon)
+  real(c_double), value, intent(in) :: depth_hpa
+  real(c_double), intent(out) :: out_p3(nlev, nlat, nlon)
+  real(c_double), intent(out) :: out_t3(nlev, nlat, nlon)
+  real(c_double), intent(out) :: out_td3(nlev, nlat, nlon)
+  integer(c_int), intent(out) :: out_idx3(nlev, nlat, nlon)
+  call most_unstable_parcel_grid_impl(int(nlev), int(nlat), int(nlon), pressure_3d, t_3d, td_3d, depth_hpa, out_p3, out_t3, out_td3, out_idx3)
+end subroutine most_unstable_parcel_grid_c
+
+subroutine mucape_c(nlev, pressure_hpa, temperature_c, dewpoint_c, depth_hpa, cape, cin, lfc_p, el_p) bind(C, name="mucape_c")
+  use iso_c_binding, only: c_double, c_int
+  use cape_mod, only: mucape_profile_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev
+  real(c_double), intent(in) :: pressure_hpa(nlev)
+  real(c_double), intent(in) :: temperature_c(nlev)
+  real(c_double), intent(in) :: dewpoint_c(nlev)
+  real(c_double), value, intent(in) :: depth_hpa
+  real(c_double), intent(out) :: cape, cin, lfc_p, el_p
+  call mucape_profile_impl(int(nlev), pressure_hpa, temperature_c, dewpoint_c, depth_hpa, cape, cin, lfc_p, el_p)
+end subroutine mucape_c
+
+subroutine mucape_grid_c(nlev, nlat, nlon, pressure_3d, t_3d, td_3d, depth_hpa, cape2, cin2, lfc2, el2) bind(C, name="mucape_grid_c")
+  use iso_c_binding, only: c_double, c_int
+  use cape_mod, only: mucape_grid_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev, nlat, nlon
+  real(c_double), intent(in) :: pressure_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: t_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: td_3d(nlev, nlat, nlon)
+  real(c_double), value, intent(in) :: depth_hpa
+  real(c_double), intent(out) :: cape2(nlat, nlon)
+  real(c_double), intent(out) :: cin2(nlat, nlon)
+  real(c_double), intent(out) :: lfc2(nlat, nlon)
+  real(c_double), intent(out) :: el2(nlat, nlon)
+  call mucape_grid_impl(int(nlev), int(nlat), int(nlon), pressure_3d, t_3d, td_3d, depth_hpa, cape2, cin2, lfc2, el2)
+end subroutine mucape_grid_c

--- a/src/skyborn/calc/cape/meson.build
+++ b/src/skyborn/calc/cape/meson.build
@@ -1,0 +1,144 @@
+# Skyborn CAPE submodule - direct Fortran/C extension
+project(
+  'skyborn-cape',
+  ['c', 'fortran'],
+  version: '1.0.0',
+  default_options: ['warning_level=2', 'buildtype=release', 'b_lto=true'],
+)
+
+py_mod = import('python')
+py = py_mod.find_installation(pure: false)
+py_dep = py.dependency()
+build_py = find_program('build_python', required: false)
+if not build_py.found()
+  build_py = py
+endif
+
+py.install_sources(
+  [
+    '__init__.py',
+    'core.py',
+  ],
+  subdir: 'skyborn/calc/cape',
+)
+
+incdir_numpy_cmd = run_command(
+  build_py,
+  [
+    '-c',
+    '''
+import numpy
+import os
+paths = [
+    numpy.get_include(),
+    os.path.join(numpy.__path__[0], "core", "include"),
+    os.path.join(numpy.__path__[0], "_core", "include"),
+]
+for path in paths:
+    if os.path.exists(os.path.join(path, "numpy", "npy_os.h")):
+        print(path)
+        break
+else:
+    print(numpy.get_include())
+''',
+  ],
+  check: true,
+)
+inc_np = include_directories(incdir_numpy_cmd.stdout().strip())
+
+host_system = host_machine.system()
+host_cpu = host_machine.cpu_family()
+cc = meson.get_compiler('c')
+fc = meson.get_compiler('fortran')
+
+message('NumPy include directory: ' + incdir_numpy_cmd.stdout().strip())
+message('Host system: ' + host_system)
+message('Host CPU family: ' + host_cpu)
+
+c_args = ['-DNPY_NO_DEPRECATED_API=NPY_1_19_API_VERSION']
+fortran_args = [
+  '-O3',
+  '-fPIC',
+  '-fno-second-underscore',
+  '-funroll-loops',
+  '-finline-functions',
+  '-ftree-vectorize',
+  '-ffree-line-length-none',
+  '-fno-common',
+]
+
+if host_system == 'windows' and cc.get_id() == 'msvc'
+  c_args += ['/O2']
+else
+  c_args += ['-O3', '-fPIC', '-fno-trapping-math']
+endif
+
+if fc.get_id() == 'gcc'
+  fortran_args += ['-fimplicit-none']
+endif
+
+if host_system == 'darwin' and host_cpu == 'aarch64'
+  fortran_args += ['-march=armv8-a', '-mtune=apple-m1']
+  c_args += ['-march=armv8-a', '-mtune=apple-m1']
+else
+  fortran_args += ['-march=x86-64', '-mtune=generic']
+  c_args += ['-march=x86-64', '-mtune=generic']
+endif
+
+message('Fortran args: ' + ' '.join(fortran_args))
+message('C args: ' + ' '.join(c_args))
+
+cape_ext = py.extension_module(
+  'cape_core',
+  [
+    'cape_core_module.c',
+    'fortran/cape.f90',
+    'fortran/cape_bindings.f90',
+  ],
+  include_directories: inc_np,
+  dependencies: [py_dep],
+  c_args: c_args,
+  fortran_args: fortran_args,
+  install: true,
+  install_dir: get_option('python.purelibdir') / 'skyborn' / 'calc' / 'cape',
+  build_by_default: true,
+)
+
+custom_target(
+  'copy_to_source_for_inplace',
+  input: cape_ext,
+  output: 'inplace_copy_marker.txt',
+  command: [
+    py,
+    '-c',
+    '''
+import glob
+import shutil
+from pathlib import Path
+
+current_dir = Path.cwd()
+module_dir = current_dir.parent
+
+patterns = ["cape_core*.so", "cape_core*.pyd", "cape_core*.dylib"]
+built_files = []
+for pattern in patterns:
+    built_files.extend(glob.glob(str(current_dir / pattern), recursive=False))
+for pattern in patterns:
+    built_files.extend(glob.glob(str(current_dir / "**" / pattern), recursive=True))
+
+for built_file_str in sorted(set(built_files)):
+    built_file = Path(built_file_str)
+    target = module_dir / built_file.name
+    if not target.exists() or built_file.stat().st_mtime > target.stat().st_mtime:
+        shutil.copy2(str(built_file), str(target))
+        print(f"Copied {built_file.name} to source")
+
+with open(Path("@OUTPUT@"), "w", encoding="utf-8") as marker:
+    marker.write("cape copied\n")
+''',
+  ],
+  build_by_default: true,
+  console: true,
+)
+
+message('cape submodule configured successfully with direct Fortran/C extension')

--- a/src/skyborn/calc/srh/__init__.py
+++ b/src/skyborn/calc/srh/__init__.py
@@ -1,0 +1,4 @@
+"""Storm-relative helicity calculations for Skyborn."""
+from .core import calculate_storm_relative_helicity
+
+__all__ = ["calculate_storm_relative_helicity"]

--- a/src/skyborn/calc/srh/core.py
+++ b/src/skyborn/calc/srh/core.py
@@ -1,0 +1,165 @@
+"""Storm-relative helicity calculations backed by a compiled Fortran/C extension.
+
+Inputs (plain floats/arrays, all MKS or angle-free):
+
+* ``height`` in meters (converted to AGL internally)
+* ``u``, ``v`` in m/s
+* ``depth`` in meters (layer depth, required)
+* ``bottom`` in meters AGL (default 0)
+* ``storm_u``, ``storm_v`` in m/s (default 0)
+
+Outputs (m^2/s^2): positive SRH, negative SRH, and total SRH. The algorithm
+follows metpy's ``storm_relative_helicity``: heights are converted to AGL,
+the layer [bottom, bottom+depth] is subsampled with the boundary heights
+linearly interpolated (NaN outside the data range, matching metpy), and the
+hodograph cross terms are summed separately for positive/negative/zero.
+
+1D input returns three floats; 3D input (level, lat, lon) returns three 2D
+fields, wrapped as xarray DataArrays when given xarray input.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Union
+
+import numpy as np
+import xarray as xr
+
+__all__ = [
+    "calculate_storm_relative_helicity",
+    "srh_profile",
+    "srh_grid",
+]
+
+_BACKEND = import_module(f"{__package__}.srh_core")
+
+
+def _as_numpy(values):
+    return getattr(values, "values", values)
+
+
+def _wrap_xarray_result(height: xr.DataArray, values: np.ndarray) -> xr.DataArray:
+    dims = list(height.dims[-2:])
+    coords = {}
+    for dim in dims:
+        if dim in height.coords:
+            coords[dim] = height.coords[dim]
+    return xr.DataArray(
+        values,
+        dims=dims or ["y", "x"],
+        coords=coords,
+        attrs={"units": "m2 s-2", "long_name": "storm-relative helicity"},
+    )
+
+
+def srh_profile(
+    height: Union[np.ndarray, xr.DataArray],
+    u: Union[np.ndarray, xr.DataArray],
+    v: Union[np.ndarray, xr.DataArray],
+    depth: float,
+    bottom: float = 0.0,
+    storm_u: float = 0.0,
+    storm_v: float = 0.0,
+):
+    """Compute (positive, negative, total) SRH for a single profile."""
+    h = np.asarray(_as_numpy(height), dtype=np.float64)
+    ua = np.asarray(_as_numpy(u), dtype=np.float64)
+    va = np.asarray(_as_numpy(v), dtype=np.float64)
+    if h.ndim != 1:
+        raise ValueError(f"height must be 1D, got shape {h.shape}")
+    if ua.shape != h.shape or va.shape != h.shape:
+        raise ValueError("height, u, and v must share a shape")
+    return tuple(
+        float(x)
+        for x in _BACKEND.srh_profile(
+            np.ascontiguousarray(h),
+            np.ascontiguousarray(ua),
+            np.ascontiguousarray(va),
+            float(depth),
+            float(bottom),
+            float(storm_u),
+            float(storm_v),
+        )
+    )
+
+
+def srh_grid(
+    height: Union[np.ndarray, xr.DataArray],
+    u: Union[np.ndarray, xr.DataArray],
+    v: Union[np.ndarray, xr.DataArray],
+    depth: float,
+    bottom: float = 0.0,
+    storm_u: float = 0.0,
+    storm_v: float = 0.0,
+):
+    """Compute (positive, negative, total) SRH for a 3D grid of profiles."""
+    h = np.asarray(_as_numpy(height), dtype=np.float64)
+    ua = np.asarray(_as_numpy(u), dtype=np.float64)
+    va = np.asarray(_as_numpy(v), dtype=np.float64)
+    if h.ndim != 3:
+        raise ValueError(f"height must be 3D, got shape {h.shape}")
+    if ua.shape != h.shape or va.shape != h.shape:
+        raise ValueError("height, u, and v must share a shape")
+    return tuple(
+        np.asarray(arr, dtype=np.float64)
+        for arr in _BACKEND.srh_grid(
+            np.asfortranarray(h),
+            np.asfortranarray(ua),
+            np.asfortranarray(va),
+            float(depth),
+            float(bottom),
+            float(storm_u),
+            float(storm_v),
+        )
+    )
+
+
+def calculate_storm_relative_helicity(
+    height: Union[np.ndarray, xr.DataArray],
+    u: Union[np.ndarray, xr.DataArray],
+    v: Union[np.ndarray, xr.DataArray],
+    depth: float,
+    *,
+    bottom: float = 0.0,
+    storm_u: float = 0.0,
+    storm_v: float = 0.0,
+):
+    """Calculate storm-relative helicity.
+
+    Parameters
+    ----------
+    height : np.ndarray or xr.DataArray
+        Atmospheric height in meters. Either 1D (level,) or 3D (level, lat, lon).
+    u : np.ndarray or xr.DataArray
+        U-component wind in m/s, same shape as ``height``.
+    v : np.ndarray or xr.DataArray
+        V-component wind in m/s, same shape as ``height``.
+    depth : float
+        Depth of the layer in meters.
+    bottom : float, optional
+        Height of the layer bottom AGL in meters (default 0, i.e. surface).
+    storm_u, storm_v : float, optional
+        U/V components of storm motion in m/s (default 0).
+
+    Returns
+    -------
+    tuple of (positive_srh, negative_srh, total_srh)
+        For 1D input: three floats in m^2/s^2. For 3D input: three 2D arrays
+        (lat, lon), wrapped as ``xr.DataArray`` for xarray input.
+    """
+    h = _as_numpy(height)
+    ua = _as_numpy(u)
+    va = _as_numpy(v)
+    is_xarray = hasattr(height, "attrs")
+
+    if np.ndim(h) == 1:
+        return srh_profile(h, ua, va, depth, bottom, storm_u, storm_v)
+
+    if np.ndim(h) == 3:
+        out = srh_grid(h, ua, va, depth, bottom, storm_u, storm_v)
+        if is_xarray:
+            out = tuple(_wrap_xarray_result(height, arr) for arr in out)
+        return out
+
+    raise ValueError(f"height must be 1D or 3D, got shape {np.shape(h)}")

--- a/src/skyborn/calc/srh/fortran/srh.f90
+++ b/src/skyborn/calc/srh/fortran/srh.f90
@@ -1,0 +1,215 @@
+module srh_mod
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite, ieee_quiet_nan, ieee_value
+  use iso_c_binding, only: c_double
+  implicit none
+  private
+  public :: srh_profile_impl, srh_grid_impl
+
+contains
+
+  !--------------------------------------------------------------------------
+  ! Linear interpolation of val(z) on the sorted, ascending abscissa h(:).
+  ! Points outside [h(1), h(m)] return NaN, matching metpy's interpolate_1d
+  ! with its default fill_value=np.nan.
+  real(c_double) function interp_linear(z, m, h, val) result(v)
+    real(c_double), intent(in) :: z
+    integer, intent(in) :: m
+    real(c_double), intent(in) :: h(m), val(m)
+    real(c_double) :: w
+    integer :: i
+
+    v = ieee_value(0.0d0, ieee_quiet_nan)
+    if (m < 2) return
+    if (z < h(1) .or. z > h(m)) return
+    if (z == h(1)) then
+      v = val(1)
+      return
+    end if
+    do i = 1, m - 1
+      if (h(i) <= z .and. z <= h(i + 1)) then
+        if (abs(h(i + 1) - h(i)) < 1.0d-12) then
+          v = val(i)
+        else
+          w = (z - h(i)) / (h(i + 1) - h(i))
+          v = val(i) + w * (val(i + 1) - val(i))
+        end if
+        return
+      end if
+    end do
+  end function interp_linear
+
+  !--------------------------------------------------------------------------
+  ! Insert (z_bound, u_bound, v_bound) into the ordered layer arrays,
+  ! keeping ascending order by height. Caller checks membership first.
+  subroutine insert_bound(n, h_lay, u_lay, v_lay, z_bound, u_bound, v_bound)
+    integer, intent(inout) :: n
+    real(c_double), intent(inout) :: h_lay(:), u_lay(:), v_lay(:)
+    real(c_double), intent(in) :: z_bound, u_bound, v_bound
+    integer :: i, pos
+
+    pos = n + 1
+    do i = 1, n
+      if (h_lay(i) > z_bound) then
+        pos = i
+        exit
+      end if
+    end do
+    do i = n, pos, -1
+      h_lay(i + 1) = h_lay(i)
+      u_lay(i + 1) = u_lay(i)
+      v_lay(i + 1) = v_lay(i)
+    end do
+    h_lay(pos) = z_bound
+    u_lay(pos) = u_bound
+    v_lay(pos) = v_bound
+    n = n + 1
+  end subroutine insert_bound
+
+  !--------------------------------------------------------------------------
+  ! Sort h ascending together with u and v (simple insertion sort).
+  subroutine sort3(m, h, u, v)
+    integer, intent(in) :: m
+    real(c_double), intent(inout) :: h(m), u(m), v(m)
+    real(c_double) :: th, tu, tv
+    integer :: i, j
+    do i = 2, m
+      th = h(i)
+      tu = u(i)
+      tv = v(i)
+      j = i - 1
+      do while (j >= 1 .and. h(j) > th)
+        h(j + 1) = h(j)
+        u(j + 1) = u(j)
+        v(j + 1) = v(j)
+        j = j - 1
+      end do
+      h(j + 1) = th
+      u(j + 1) = tu
+      v(j + 1) = tv
+    end do
+  end subroutine sort3
+
+  !--------------------------------------------------------------------------
+  ! Single-profile storm-relative helicity.
+  ! Mirrors metpy: AGL heights, layer [bottom, bottom+depth] with the
+  ! boundary heights linearly interpolated (NaN when out of range), then
+  ! int_layers = (ur_{n+1}*vr_n - ur_n*vr_{n+1}) summed with sign split.
+  subroutine srh_profile_impl(nlev, height_m, u_ms, v_ms, depth_m, bottom_m, &
+                              storm_u_ms, storm_v_ms, srh_pos, srh_neg, srh_total)
+    integer, intent(in) :: nlev
+    real(c_double), intent(in) :: height_m(nlev)
+    real(c_double), intent(in) :: u_ms(nlev)
+    real(c_double), intent(in) :: v_ms(nlev)
+    real(c_double), intent(in) :: depth_m, bottom_m
+    real(c_double), intent(in) :: storm_u_ms, storm_v_ms
+    real(c_double), intent(out) :: srh_pos, srh_neg, srh_total
+
+    real(c_double), allocatable :: h(:), u(:), v(:)
+    real(c_double), allocatable :: h_lay(:), u_lay(:), v_lay(:)
+    real(c_double) :: hmin, top_m, u_b, v_b, ur, vr, term
+    integer :: m, k, n_lay, has_bottom, has_top
+
+    srh_pos = 0.0d0
+    srh_neg = 0.0d0
+    srh_total = 0.0d0
+
+    allocate(h(nlev), u(nlev), v(nlev))
+    m = 0
+    do k = 1, nlev
+      if (ieee_is_finite(height_m(k)) .and. ieee_is_finite(u_ms(k)) .and. &
+          ieee_is_finite(v_ms(k))) then
+        m = m + 1
+        h(m) = height_m(k)
+        u(m) = u_ms(k)
+        v(m) = v_ms(k)
+      end if
+    end do
+    if (m < 2) then
+      deallocate(h, u, v)
+      return
+    end if
+
+    ! Above ground level
+    hmin = minval(h(1:m))
+    h(1:m) = h(1:m) - hmin
+
+    ! Ascending sort
+    call sort3(m, h, u, v)
+
+    top_m = bottom_m + depth_m
+
+    ! Collect data levels within [bottom, top] (ascending)
+    allocate(h_lay(2 * m + 2), u_lay(2 * m + 2), v_lay(2 * m + 2))
+    n_lay = 0
+    do k = 1, m
+      if (h(k) >= bottom_m .and. h(k) <= top_m) then
+        n_lay = n_lay + 1
+        h_lay(n_lay) = h(k)
+      end if
+    end do
+
+    ! Insert boundary heights with interpolated winds if not exactly present
+    has_bottom = 0
+    has_top = 0
+    do k = 1, n_lay
+      if (h_lay(k) == bottom_m) has_bottom = 1
+      if (h_lay(k) == top_m) has_top = 1
+    end do
+    if (has_bottom == 0) then
+      u_b = interp_linear(bottom_m, m, h, u)
+      call insert_bound(n_lay, h_lay, u_lay, v_lay, bottom_m, u_b, &
+                        interp_linear(bottom_m, m, h, v))
+    end if
+    if (has_top == 0) then
+      u_b = interp_linear(top_m, m, h, u)
+      call insert_bound(n_lay, h_lay, u_lay, v_lay, top_m, u_b, &
+                        interp_linear(top_m, m, h, v))
+    end if
+
+    ! Note: u_lay for data levels is filled lazily below via interpolation
+    ! from the raw profile (identical to metpy interpolate_1d).
+    do k = 1, n_lay
+      u_lay(k) = interp_linear(h_lay(k), m, h, u) - storm_u_ms
+      v_lay(k) = interp_linear(h_lay(k), m, h, v) - storm_v_ms
+    end do
+
+    ! Sum the cross terms, skipping NaN entries (metpy's masking semantics)
+    do k = 1, n_lay - 1
+      ur = u_lay(k + 1) * v_lay(k) - u_lay(k) * v_lay(k + 1)
+      if (ieee_is_finite(ur)) then
+        if (ur > 0.0d0) then
+          srh_pos = srh_pos + ur
+        else if (ur < 0.0d0) then
+          srh_neg = srh_neg + ur
+        end if
+        srh_total = srh_total + ur
+      end if
+    end do
+
+    deallocate(h, u, v, h_lay, u_lay, v_lay)
+  end subroutine srh_profile_impl
+
+  !--------------------------------------------------------------------------
+  ! Grid version: depth, bottom, and storm motion are scalars.
+  subroutine srh_grid_impl(nlev, nlat, nlon, h3, u3, v3, depth_m, bottom_m, &
+                           storm_u_ms, storm_v_ms, pos2, neg2, tot2)
+    integer, intent(in) :: nlev, nlat, nlon
+    real(c_double), intent(in) :: h3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: u3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: v3(nlev, nlat, nlon)
+    real(c_double), intent(in) :: depth_m, bottom_m
+    real(c_double), intent(in) :: storm_u_ms, storm_v_ms
+    real(c_double), intent(out) :: pos2(nlat, nlon)
+    real(c_double), intent(out) :: neg2(nlat, nlon)
+    real(c_double), intent(out) :: tot2(nlat, nlon)
+    integer :: j, i
+    do i = 1, nlon
+      do j = 1, nlat
+        call srh_profile_impl(nlev, h3(:, j, i), u3(:, j, i), v3(:, j, i), &
+                              depth_m, bottom_m, storm_u_ms, storm_v_ms, &
+                              pos2(j, i), neg2(j, i), tot2(j, i))
+      end do
+    end do
+  end subroutine srh_grid_impl
+
+end module srh_mod

--- a/src/skyborn/calc/srh/fortran/srh_bindings.f90
+++ b/src/skyborn/calc/srh/fortran/srh_bindings.f90
@@ -1,0 +1,27 @@
+subroutine srh_profile_c(nlev, height_m, u_ms, v_ms, depth_m, bottom_m, storm_u_ms, storm_v_ms, srh_pos, srh_neg, srh_total) bind(C, name="srh_profile_c")
+  use iso_c_binding, only: c_double, c_int
+  use srh_mod, only: srh_profile_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev
+  real(c_double), intent(in) :: height_m(nlev)
+  real(c_double), intent(in) :: u_ms(nlev)
+  real(c_double), intent(in) :: v_ms(nlev)
+  real(c_double), value, intent(in) :: depth_m, bottom_m, storm_u_ms, storm_v_ms
+  real(c_double), intent(out) :: srh_pos, srh_neg, srh_total
+  call srh_profile_impl(int(nlev), height_m, u_ms, v_ms, depth_m, bottom_m, storm_u_ms, storm_v_ms, srh_pos, srh_neg, srh_total)
+end subroutine srh_profile_c
+
+subroutine srh_grid_c(nlev, nlat, nlon, height_3d, u_3d, v_3d, depth_m, bottom_m, storm_u_ms, storm_v_ms, pos2, neg2, tot2) bind(C, name="srh_grid_c")
+  use iso_c_binding, only: c_double, c_int
+  use srh_mod, only: srh_grid_impl
+  implicit none
+  integer(c_int), value, intent(in) :: nlev, nlat, nlon
+  real(c_double), intent(in) :: height_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: u_3d(nlev, nlat, nlon)
+  real(c_double), intent(in) :: v_3d(nlev, nlat, nlon)
+  real(c_double), value, intent(in) :: depth_m, bottom_m, storm_u_ms, storm_v_ms
+  real(c_double), intent(out) :: pos2(nlat, nlon)
+  real(c_double), intent(out) :: neg2(nlat, nlon)
+  real(c_double), intent(out) :: tot2(nlat, nlon)
+  call srh_grid_impl(int(nlev), int(nlat), int(nlon), height_3d, u_3d, v_3d, depth_m, bottom_m, storm_u_ms, storm_v_ms, pos2, neg2, tot2)
+end subroutine srh_grid_c

--- a/src/skyborn/calc/srh/meson.build
+++ b/src/skyborn/calc/srh/meson.build
@@ -1,0 +1,137 @@
+# Skyborn SRH submodule - direct Fortran/C extension
+project(
+  'skyborn-srh',
+  ['c', 'fortran'],
+  version: '1.0.0',
+  default_options: ['warning_level=2', 'buildtype=release', 'b_lto=true'],
+)
+
+py_mod = import('python')
+py = py_mod.find_installation(pure: false)
+py_dep = py.dependency()
+build_py = find_program('build_python', required: false)
+if not build_py.found()
+  build_py = py
+endif
+
+py.install_sources(
+  [
+    '__init__.py',
+    'core.py',
+  ],
+  subdir: 'skyborn/calc/srh',
+)
+
+incdir_numpy_cmd = run_command(
+  build_py,
+  [
+    '-c',
+    '''
+import numpy
+import os
+paths = [
+    numpy.get_include(),
+    os.path.join(numpy.__path__[0], "core", "include"),
+    os.path.join(numpy.__path__[0], "_core", "include"),
+]
+for path in paths:
+    if os.path.exists(os.path.join(path, "numpy", "npy_os.h")):
+        print(path)
+        break
+else:
+    print(numpy.get_include())
+''',
+  ],
+  check: true,
+)
+inc_np = include_directories(incdir_numpy_cmd.stdout().strip())
+
+host_system = host_machine.system()
+host_cpu = host_machine.cpu_family()
+cc = meson.get_compiler('c')
+fc = meson.get_compiler('fortran')
+
+c_args = ['-DNPY_NO_DEPRECATED_API=NPY_1_19_API_VERSION']
+fortran_args = [
+  '-O3',
+  '-fPIC',
+  '-fno-second-underscore',
+  '-funroll-loops',
+  '-finline-functions',
+  '-ftree-vectorize',
+  '-ffree-line-length-none',
+  '-fno-common',
+]
+
+if host_system == 'windows' and cc.get_id() == 'msvc'
+  c_args += ['/O2']
+else
+  c_args += ['-O3', '-fPIC', '-fno-trapping-math']
+endif
+
+if fc.get_id() == 'gcc'
+  fortran_args += ['-fimplicit-none']
+endif
+
+if host_system == 'darwin' and host_cpu == 'aarch64'
+  fortran_args += ['-march=armv8-a', '-mtune=apple-m1']
+  c_args += ['-march=armv8-a', '-mtune=apple-m1']
+else
+  fortran_args += ['-march=x86-64', '-mtune=generic']
+  c_args += ['-march=x86-64', '-mtune=generic']
+endif
+
+srh_ext = py.extension_module(
+  'srh_core',
+  [
+    'srh_core_module.c',
+    'fortran/srh.f90',
+    'fortran/srh_bindings.f90',
+  ],
+  include_directories: inc_np,
+  dependencies: [py_dep],
+  c_args: c_args,
+  fortran_args: fortran_args,
+  install: true,
+  install_dir: get_option('python.purelibdir') / 'skyborn' / 'calc' / 'srh',
+  build_by_default: true,
+)
+
+custom_target(
+  'copy_to_source_for_inplace',
+  input: srh_ext,
+  output: 'inplace_copy_marker.txt',
+  command: [
+    py,
+    '-c',
+    '''
+import glob
+import shutil
+from pathlib import Path
+
+current_dir = Path.cwd()
+module_dir = current_dir.parent
+
+patterns = ["srh_core*.so", "srh_core*.pyd", "srh_core*.dylib"]
+built_files = []
+for pattern in patterns:
+    built_files.extend(glob.glob(str(current_dir / pattern), recursive=False))
+for pattern in patterns:
+    built_files.extend(glob.glob(str(current_dir / "**" / pattern), recursive=True))
+
+for built_file_str in sorted(set(built_files)):
+    built_file = Path(built_file_str)
+    target = module_dir / built_file.name
+    if not target.exists() or built_file.stat().st_mtime > target.stat().st_mtime:
+        shutil.copy2(str(built_file), str(target))
+        print(f"Copied {built_file.name} to source")
+
+with open(Path("@OUTPUT@"), "w", encoding="utf-8") as marker:
+    marker.write("srh copied\n")
+''',
+  ],
+  build_by_default: true,
+  console: true,
+)
+
+message('srh submodule configured successfully with direct Fortran/C extension')

--- a/src/skyborn/calc/srh/srh_core_module.c
+++ b/src/skyborn/calc/srh/srh_core_module.c
@@ -1,0 +1,190 @@
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_19_API_VERSION
+#include <Python.h>
+#include <numpy/arrayobject.h>
+
+void srh_profile_c(
+    int nlev, void *height_m, void *u_ms, void *v_ms,
+    double depth_m, double bottom_m, double storm_u_ms, double storm_v_ms,
+    void *srh_pos, void *srh_neg, void *srh_total);
+void srh_grid_c(
+    int nlev, int nlat, int nlon,
+    void *height_3d, void *u_3d, void *v_3d,
+    double depth_m, double bottom_m, double storm_u_ms, double storm_v_ms,
+    void *pos2, void *neg2, void *tot2);
+
+/* ---------------- srh_profile: single vertical profile ---------------- */
+static PyObject *py_srh_profile(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *height_obj = NULL;
+    PyObject *u_obj = NULL;
+    PyObject *v_obj = NULL;
+    PyArrayObject *height_arr = NULL;
+    PyArrayObject *u_arr = NULL;
+    PyArrayObject *v_arr = NULL;
+    double depth = 0.0, bottom = 0.0, storm_u = 0.0, storm_v = 0.0;
+    double srh_pos = 0.0, srh_neg = 0.0, srh_total = 0.0;
+    int nlev;
+    static char *kwlist[] = {"height", "u", "v", "depth", "bottom",
+                             "storm_u", "storm_v", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOOd|ddd", kwlist,
+                                     &height_obj, &u_obj, &v_obj, &depth,
+                                     &bottom, &storm_u, &storm_v))
+    {
+        return NULL;
+    }
+    height_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        height_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    u_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        u_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    v_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        v_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS);
+    if (height_arr == NULL || u_arr == NULL || v_arr == NULL)
+    {
+        Py_XDECREF(height_arr);
+        Py_XDECREF(u_arr);
+        Py_XDECREF(v_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(height_arr) != 1 || PyArray_NDIM(u_arr) != 1 ||
+        PyArray_NDIM(v_arr) != 1)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "height, u, and v must be 1D arrays");
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(height_arr, 0);
+    if ((int) PyArray_DIM(u_arr, 0) != nlev || (int) PyArray_DIM(v_arr, 0) != nlev)
+    {
+        PyErr_SetString(PyExc_ValueError, "height, u, and v must share a length");
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    srh_profile_c(nlev, PyArray_DATA(height_arr), PyArray_DATA(u_arr),
+                  PyArray_DATA(v_arr), depth, bottom, storm_u, storm_v,
+                  &srh_pos, &srh_neg, &srh_total);
+    Py_END_ALLOW_THREADS
+    Py_DECREF(height_arr);
+    Py_DECREF(u_arr);
+    Py_DECREF(v_arr);
+    return Py_BuildValue("ddd", srh_pos, srh_neg, srh_total);
+fail:
+    Py_XDECREF(height_arr);
+    Py_XDECREF(u_arr);
+    Py_XDECREF(v_arr);
+    return NULL;
+}
+
+/* ---------------- srh_grid: 3D grid of profiles ---------------- */
+static PyObject *py_srh_grid(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *height_obj = NULL;
+    PyObject *u_obj = NULL;
+    PyObject *v_obj = NULL;
+    PyArrayObject *height_arr = NULL;
+    PyArrayObject *u_arr = NULL;
+    PyArrayObject *v_arr = NULL;
+    PyArrayObject *pos_arr = NULL, *neg_arr = NULL, *tot_arr = NULL;
+    PyObject *result = NULL;
+    npy_intp dims[2];
+    double depth = 0.0, bottom = 0.0, storm_u = 0.0, storm_v = 0.0;
+    int nlev, nlat, nlon;
+    static char *kwlist[] = {"height", "u", "v", "depth", "bottom",
+                             "storm_u", "storm_v", NULL};
+    (void) self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOOd|ddd", kwlist,
+                                     &height_obj, &u_obj, &v_obj, &depth,
+                                     &bottom, &storm_u, &storm_v))
+    {
+        return NULL;
+    }
+    height_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        height_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    u_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        u_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    v_arr = (PyArrayObject *) PyArray_FROM_OTF(
+        v_obj, NPY_FLOAT64, NPY_ARRAY_ALIGNED | NPY_ARRAY_F_CONTIGUOUS);
+    if (height_arr == NULL || u_arr == NULL || v_arr == NULL)
+    {
+        Py_XDECREF(height_arr);
+        Py_XDECREF(u_arr);
+        Py_XDECREF(v_arr);
+        return NULL;
+    }
+    if (PyArray_NDIM(height_arr) != 3 || PyArray_NDIM(u_arr) != 3 ||
+        PyArray_NDIM(v_arr) != 3)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "height, u, and v must be 3D arrays");
+        goto fail;
+    }
+    nlev = (int) PyArray_DIM(height_arr, 0);
+    nlat = (int) PyArray_DIM(height_arr, 1);
+    nlon = (int) PyArray_DIM(height_arr, 2);
+    if (PyArray_DIM(u_arr, 0) != nlev || PyArray_DIM(u_arr, 1) != nlat ||
+        PyArray_DIM(u_arr, 2) != nlon || PyArray_DIM(v_arr, 0) != nlev ||
+        PyArray_DIM(v_arr, 1) != nlat || PyArray_DIM(v_arr, 2) != nlon)
+    {
+        PyErr_SetString(PyExc_ValueError, "height, u, and v must share a shape");
+        goto fail;
+    }
+    dims[0] = nlat;
+    dims[1] = nlon;
+    pos_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    neg_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    tot_arr = (PyArrayObject *) PyArray_EMPTY(2, dims, NPY_FLOAT64, 1);
+    if (pos_arr == NULL || neg_arr == NULL || tot_arr == NULL)
+    {
+        goto fail;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    srh_grid_c(nlev, nlat, nlon, PyArray_DATA(height_arr), PyArray_DATA(u_arr),
+               PyArray_DATA(v_arr), depth, bottom, storm_u, storm_v,
+               PyArray_DATA(pos_arr), PyArray_DATA(neg_arr), PyArray_DATA(tot_arr));
+    Py_END_ALLOW_THREADS
+    result = Py_BuildValue("NNN", (PyObject *) pos_arr, (PyObject *) neg_arr,
+                           (PyObject *) tot_arr);
+    Py_DECREF(height_arr);
+    Py_DECREF(u_arr);
+    Py_DECREF(v_arr);
+    return result;
+fail:
+    Py_XDECREF(height_arr);
+    Py_XDECREF(u_arr);
+    Py_XDECREF(v_arr);
+    Py_XDECREF(pos_arr);
+    Py_XDECREF(neg_arr);
+    Py_XDECREF(tot_arr);
+    return NULL;
+}
+
+static PyMethodDef module_methods[] = {
+    {"srh_profile", (PyCFunction) (void (*)(void)) py_srh_profile,
+     METH_VARARGS | METH_KEYWORDS,
+     "Compute (positive, negative, total) storm-relative helicity for one profile."},
+    {"srh_grid", (PyCFunction) (void (*)(void)) py_srh_grid,
+     METH_VARARGS | METH_KEYWORDS,
+     "Compute storm-relative helicity for a 3D grid of profiles."},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "srh_core",
+    NULL,
+    -1,
+    module_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+PyMODINIT_FUNC PyInit_srh_core(void)
+{
+    import_array();
+    return PyModule_Create(&moduledef);
+}

--- a/tests/test_calc_cape.py
+++ b/tests/test_calc_cape.py
@@ -1,0 +1,326 @@
+import importlib
+
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_allclose
+
+import skyborn.calc.cape as cape_package
+import skyborn.calc.cape.core as cape_core
+
+# ---------------------------------------------------------------------------
+# Reference sounding (metpy 1.7.1 docstring case). Dewpoint derived from RH
+# with the same Magnus formula used by the Fortran backend.
+# ---------------------------------------------------------------------------
+_SOUNDING_P = np.array(
+    [
+        1008.0, 1000.0, 950.0, 900.0, 850.0, 800.0, 750.0, 700.0, 650.0, 600.0,
+        550.0, 500.0, 450.0, 400.0, 350.0, 300.0, 250.0, 200.0,
+        175.0, 150.0, 125.0, 100.0, 80.0, 70.0, 60.0, 50.0,
+        40.0, 30.0, 25.0, 20.0,
+    ]
+)
+_SOUNDING_T = np.array(
+    [
+        29.3, 28.1, 23.5, 20.9, 18.4, 15.9, 13.1, 10.1, 6.7, 3.1,
+        -0.5, -4.5, -9.0, -14.8, -21.5, -29.7, -40.0, -52.4,
+        -59.2, -66.5, -74.1, -78.5, -76.0, -71.6, -66.7, -61.3,
+        -56.3, -51.7, -50.7, -47.5,
+    ]
+)
+_SOUNDING_RH = np.array(
+    [
+        0.85, 0.65, 0.36, 0.39, 0.82, 0.72, 0.75, 0.86, 0.65, 0.22, 0.52,
+        0.66, 0.64, 0.20, 0.05, 0.75, 0.76, 0.45, 0.25, 0.48, 0.76, 0.88,
+        0.56, 0.88, 0.39, 0.67, 0.15, 0.04, 0.94, 0.35,
+    ]
+)
+
+# metpy 1.7.1 results (Romps LCL + LSODA integrator). The Skyborn backend
+# uses the Bolton LCL + fixed-step RK4, so a 5% relative tolerance applies.
+_METPY_CAPE = 4830.746079707783
+_METPY_CIN = 0.0
+_METPY_LFC = 913.55
+_METPY_EL = 112.25
+
+
+def _sounding_dewpoint():
+    es = 6.112 * np.exp(17.67 * _SOUNDING_T / (_SOUNDING_T + 243.5))
+    e = _SOUNDING_RH * es
+    return 243.5 * np.log(e / 6.112) / (17.67 - np.log(e / 6.112))
+
+
+def _sample_profile():
+    """Compact unstable profile with non-zero CIN (stable low levels)."""
+    pressure = np.array(
+        [1000.0, 950.0, 900.0, 850.0, 800.0, 750.0, 700.0, 650.0, 600.0,
+         550.0, 500.0, 450.0, 400.0, 350.0, 300.0, 250.0, 200.0, 150.0, 100.0]
+    )
+    temperature = np.array(
+        [30.0, 29.0, 28.0, 27.0, 18.0, 15.0, 12.0, 9.0, 6.0, 3.0, 0.0,
+         -4.0, -9.0, -15.0, -23.0, -33.0, -46.0, -64.0, -80.0]
+    )
+    dewpoint = np.array(
+        [24.0, 23.0, 22.0, 21.0, 14.0, 11.0, 8.0, 5.0, 2.0, -1.0, -4.0,
+         -8.0, -13.0, -19.0, -27.0, -37.0, -50.0, -68.0, -85.0]
+    )
+    return pressure, temperature, dewpoint
+
+
+def _sample_grid():
+    pressure, temperature, dewpoint = _sample_profile()
+    pressure_3d = np.broadcast_to(pressure[:, None, None], (19, 2, 3)).copy()
+    temperature_3d = np.broadcast_to(temperature[:, None, None], (19, 2, 3)).copy()
+    dewpoint_3d = np.broadcast_to(dewpoint[:, None, None], (19, 2, 3)).copy()
+    return pressure_3d, temperature_3d, dewpoint_3d
+
+
+# ---------------------------------------------------------------------------
+# Package exports
+# ---------------------------------------------------------------------------
+def test_calc_package_exports_cape_submodule_and_function():
+    calc_module = importlib.reload(importlib.import_module("skyborn.calc"))
+
+    assert calc_module.cape is cape_package
+    assert calc_module.calculate_cape_cin is cape_package.calculate_cape_cin
+    assert calc_module.calculate_parcel_profile is cape_package.calculate_parcel_profile
+    assert (
+        calc_module.calculate_most_unstable_parcel
+        is cape_package.calculate_most_unstable_parcel
+    )
+    assert (
+        calc_module.calculate_most_unstable_cape_cin
+        is cape_package.calculate_most_unstable_cape_cin
+    )
+
+
+# ---------------------------------------------------------------------------
+# Most unstable parcel / CAPE
+# ---------------------------------------------------------------------------
+def test_most_unstable_parcel_matches_metpy():
+    """metpy docstring: depth=50 hPa -> (1008, 29.3, 26.4767, 0)."""
+    pressure = _SOUNDING_P
+    temperature = _SOUNDING_T
+    dewpoint = _sounding_dewpoint()
+
+    mup_p, mup_t, mup_td, mup_idx = cape_package.calculate_most_unstable_parcel(
+        pressure, temperature, dewpoint, depth=50.0
+    )
+    assert_allclose(mup_p, 1008.0, rtol=1e-6)
+    assert_allclose(mup_t, 29.3, rtol=1e-6)
+    # dewpoint differs slightly (Magnus vs metpy formula), ~0.05 K tolerance
+    assert_allclose(mup_td, 26.4767, atol=0.1)
+    assert mup_idx == 0
+
+
+def test_most_unstable_cape_cin_matches_metpy():
+    """metpy: most_unstable_cape_cin(p, T, Td) = (4830.75, 0) for this sounding."""
+    pressure = _SOUNDING_P
+    temperature = _SOUNDING_T
+    dewpoint = _sounding_dewpoint()
+
+    mucape, mucin, _, _ = cape_package.calculate_most_unstable_cape_cin(
+        pressure, temperature, dewpoint, depth=300.0
+    )
+    assert_allclose(mucape, _METPY_CAPE, rtol=0.05, atol=50.0)
+    assert_allclose(mucin, 0.0, atol=1.0)
+
+
+def test_most_unstable_grid_matches_profile():
+    """Grid results must equal the per-column 1D results."""
+    pressure, temperature, dewpoint = _sample_profile()
+    p3 = np.broadcast_to(pressure[:, None, None], (19, 2, 3)).copy()
+    t3 = np.broadcast_to(temperature[:, None, None], (19, 2, 3)).copy()
+    td3 = np.broadcast_to(dewpoint[:, None, None], (19, 2, 3)).copy()
+
+    prof = cape_package.calculate_most_unstable_parcel(
+        pressure, temperature, dewpoint, depth=300.0
+    )
+    grid = cape_package.calculate_most_unstable_parcel(
+        p3, t3, td3, depth=300.0
+    )
+    # grid returns (p3, t3, td3, idx3): the index field stores the selected
+    # level index at that level's position; other levels stay -1
+    assert grid[3][int(prof[3]), 0, 0] == prof[3]
+    assert_allclose(grid[0][int(prof[3]), 0, 0], prof[0], rtol=1e-12)
+
+    mucape_prof = cape_package.calculate_most_unstable_cape_cin(
+        pressure, temperature, dewpoint, depth=300.0
+    )
+    mucape_grid = cape_package.calculate_most_unstable_cape_cin(
+        p3, t3, td3, depth=300.0
+    )
+    assert_allclose(mucape_grid[0][0, 0], mucape_prof[0], rtol=1e-12, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Public API vs backend consistency
+# ---------------------------------------------------------------------------
+def test_cape_public_api_matches_backend_profile():
+    pressure, temperature, dewpoint = _sample_profile()
+
+    public_result = cape_package.calculate_cape_cin(pressure, temperature, dewpoint)
+    backend_result = cape_core.cape_profile(pressure, temperature, dewpoint)
+
+    assert len(public_result) == 4
+    assert_allclose(public_result, backend_result, rtol=1e-12, atol=1e-12)
+
+
+def test_cape_public_api_matches_backend_grid_and_xarray():
+    pressure_3d, temperature_3d, dewpoint_3d = _sample_grid()
+
+    grid_result = cape_package.calculate_cape_cin(
+        pressure_3d, temperature_3d, dewpoint_3d
+    )
+    backend_grid = cape_core.cape_grid(pressure_3d, temperature_3d, dewpoint_3d)
+    for public, backend in zip(grid_result, backend_grid):
+        assert_allclose(public, backend, rtol=1e-12, atol=1e-12)
+
+    pressure_xr = xr.DataArray(
+        pressure_3d,
+        dims=["level", "lat", "lon"],
+        coords={"level": pressure_3d[:, 0, 0], "lat": [0.0, 10.0],
+                "lon": [100.0, 110.0, 120.0]},
+        attrs={"units": "hPa"},
+    )
+    temperature_xr = xr.DataArray(temperature_3d, dims=["level", "lat", "lon"])
+    dewpoint_xr = xr.DataArray(dewpoint_3d, dims=["level", "lat", "lon"])
+
+    xarray_result = cape_package.calculate_cape_cin(
+        pressure_xr, temperature_xr, dewpoint_xr
+    )
+    assert all(isinstance(r, xr.DataArray) for r in xarray_result)
+    assert xarray_result[0].dims == ("lat", "lon")
+    assert xarray_result[0].coords["lat"].values.tolist() == [0.0, 10.0]
+    for i, backend in enumerate(backend_grid):
+        assert_allclose(xarray_result[i].values, backend, rtol=1e-12, atol=1e-12)
+
+
+def test_cape_backend_is_consistent_between_profile_and_grid():
+    pressure, temperature, dewpoint = _sample_profile()
+    pressure_3d, temperature_3d, dewpoint_3d = _sample_grid()
+
+    profile_result = cape_core.cape_profile(pressure, temperature, dewpoint)
+    grid_result = cape_core.cape_grid(pressure_3d, temperature_3d, dewpoint_3d)
+
+    for i, value in enumerate(profile_result):
+        assert_allclose(
+            grid_result[i],
+            np.full((2, 3), value, dtype=np.float64),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Correctness against the metpy 1.7.1 reference sounding
+# ---------------------------------------------------------------------------
+def test_cape_matches_metpy_reference():
+    pressure = _SOUNDING_P
+    temperature = _SOUNDING_T
+    dewpoint = _sounding_dewpoint()
+
+    cape, cin, lfc, el = cape_package.calculate_cape_cin(
+        pressure, temperature, dewpoint
+    )
+
+    # Bolton LCL + RK4 vs Romps LCL + LSODA: expect agreement within 5%
+    assert_allclose(cape, _METPY_CAPE, rtol=0.05, atol=50.0)
+    assert_allclose(cin, _METPY_CIN, atol=1.0)
+    assert_allclose(lfc, _METPY_LFC, rtol=0.02)
+    assert_allclose(el, _METPY_EL, rtol=0.02)
+
+
+def test_cape_cin_sign_convention():
+    """CIN is reported <= 0 (metpy convention); positive values are clipped."""
+    pressure, temperature, dewpoint = _sample_profile()
+    cape, cin, lfc, el = cape_package.calculate_cape_cin(
+        pressure, temperature, dewpoint
+    )
+    assert cape > 0.0
+    assert cin <= 0.0
+    assert 0.0 < lfc < pressure[0]
+    assert el < lfc
+
+
+def test_cape_handles_nan_levels():
+    pressure, temperature, dewpoint = _sample_profile()
+    p2 = pressure.copy()
+    t2 = temperature.copy()
+    td2 = dewpoint.copy()
+    p2[3] = np.nan
+    t2[3] = np.nan
+    td2[3] = np.nan
+
+    cape, cin, _, _ = cape_package.calculate_cape_cin(p2, t2, td2)
+    assert np.isfinite(cape)
+    assert np.isfinite(cin)
+
+
+def test_cape_stable_profile_returns_zero():
+    """A fully stable profile has no LFC: CAPE and CIN are zero."""
+    pressure = np.array([1000.0, 900.0, 800.0, 700.0, 600.0, 500.0])
+    temperature = np.array([20.0, 18.0, 16.0, 14.0, 12.0, 10.0])
+    dewpoint = np.array([5.0, 3.0, 1.0, -1.0, -3.0, -5.0])
+
+    cape, cin, lfc, el = cape_package.calculate_cape_cin(
+        pressure, temperature, dewpoint
+    )
+    assert cape == 0.0
+    assert cin == 0.0
+    assert np.isnan(lfc)
+    assert np.isnan(el)
+
+
+# ---------------------------------------------------------------------------
+# Parcel profile
+# ---------------------------------------------------------------------------
+def test_parcel_profile_matches_metpy_reference():
+    pressure = _SOUNDING_P
+    temperature = _SOUNDING_T
+    dewpoint = _sounding_dewpoint()
+
+    profile = cape_package.calculate_parcel_profile(pressure, temperature, dewpoint)
+
+    # metpy 1.7.1 parcel profile at the first levels (degC)
+    metpy_first = np.array([29.3, 28.61221951574845, 25.174081108824907,
+                            23.410446413478496, 21.5304966888134])
+    assert_allclose(profile[:5], metpy_first, rtol=0.02, atol=0.5)
+
+
+def test_parcel_profile_grid_matches_backend():
+    pressure_3d, temperature_3d, dewpoint_3d = _sample_grid()
+
+    public = cape_package.calculate_parcel_profile(
+        pressure_3d, temperature_3d, dewpoint_3d
+    )
+    backend = cape_core.parcel_profile_grid(
+        pressure_3d, temperature_3d, dewpoint_3d
+    )
+    assert_allclose(public, backend, rtol=1e-12, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+def test_cape_input_validation():
+    with pytest.raises(ValueError, match="pressure must be 1D or 3D"):
+        cape_package.calculate_cape_cin(
+            np.ones((2, 2), dtype=float),
+            np.ones((2, 2), dtype=float),
+            np.ones((2, 2), dtype=float),
+        )
+
+    with pytest.raises(ValueError, match="pressure must be 1D"):
+        cape_core.cape_profile(
+            np.ones((2, 2), dtype=float),
+            np.ones((2, 2), dtype=float),
+            np.ones((2, 2), dtype=float),
+        )
+
+    with pytest.raises(ValueError, match="must share a shape"):
+        cape_core.cape_profile(
+            np.ones(5, dtype=float),
+            np.ones(6, dtype=float),
+            np.ones(5, dtype=float),
+        )

--- a/tests/test_calc_srh.py
+++ b/tests/test_calc_srh.py
@@ -1,0 +1,138 @@
+import importlib
+
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_allclose
+
+import skyborn.calc.srh as srh_package
+import skyborn.calc.srh.core as srh_core
+
+
+def _sample_profile():
+    """metpy 1.7.1 docstring sounding for storm_relative_helicity."""
+    height = np.array([250.0, 700.0, 1500.0, 3100.0, 5720.0, 7120.0])
+    wdir_deg = np.array([165.0, 180.0, 190.0, 210.0, 220.0, 250.0])
+    speed_knots = np.array([5.0, 15.0, 20.0, 30.0, 50.0, 60.0])
+    rad = np.deg2rad(wdir_deg)
+    speed_ms = speed_knots * 0.5144444444444445
+    # meteorological "from" convention, as metpy's wind_components
+    u = -speed_ms * np.sin(rad)
+    v = -speed_ms * np.cos(rad)
+    return height, u, v
+
+
+def _sample_grid():
+    height, u, v = _sample_profile()
+    return (
+        np.broadcast_to(height[:, None, None], (6, 2, 3)).copy(),
+        np.broadcast_to(u[:, None, None], (6, 2, 3)).copy(),
+        np.broadcast_to(v[:, None, None], (6, 2, 3)).copy(),
+    )
+
+
+def test_calc_package_exports_srh_submodule_and_function():
+    calc_module = importlib.reload(importlib.import_module("skyborn.calc"))
+    assert calc_module.srh is srh_package
+    assert (
+        calc_module.calculate_storm_relative_helicity
+        is srh_package.calculate_storm_relative_helicity
+    )
+
+
+def test_srh_matches_metpy_reference():
+    """metpy docstring case: depth=1km, storm=(7, 7) m/s -> 49.6086162."""
+    height, u, v = _sample_profile()
+    result = srh_package.calculate_storm_relative_helicity(
+        height, u, v, depth=1000.0, storm_u=7.0, storm_v=7.0
+    )
+    assert_allclose(result[0], 49.6086162, rtol=1e-9)
+    assert_allclose(result[1], 0.0, atol=1e-12)
+    assert_allclose(result[2], 49.6086162, rtol=1e-9)
+
+
+def test_srh_default_storm_is_zero():
+    height, u, v = _sample_profile()
+    result = srh_package.calculate_storm_relative_helicity(height, u, v, depth=1000.0)
+    # metpy with storm=0
+    assert_allclose(result[0], 14.6158, rtol=1e-3)
+    assert_allclose(result[2], 14.6158, rtol=1e-3)
+
+
+def test_srh_public_api_matches_backend():
+    height, u, v = _sample_profile()
+    public = srh_package.calculate_storm_relative_helicity(
+        height, u, v, depth=1000.0, storm_u=7.0, storm_v=7.0
+    )
+    backend = srh_core.srh_profile(height, u, v, 1000.0, 0.0, 7.0, 7.0)
+    assert_allclose(public, backend, rtol=1e-12, atol=1e-12)
+
+
+def test_srh_grid_matches_backend_and_xarray():
+    h3, u3, v3 = _sample_grid()
+
+    grid = srh_core.srh_grid(h3, u3, v3, 1000.0, 0.0, 7.0, 7.0)
+    profile = srh_core.srh_profile(h3[:, 0, 0], u3[:, 0, 0], v3[:, 0, 0],
+                                   1000.0, 0.0, 7.0, 7.0)
+    for i, arr in enumerate(grid):
+        assert_allclose(arr[0, 0], profile[i], rtol=1e-12, atol=1e-12)
+
+    h_xr = xr.DataArray(
+        h3,
+        dims=["level", "lat", "lon"],
+        coords={"level": h3[:, 0, 0], "lat": [0.0, 10.0], "lon": [100.0, 110.0, 120.0]},
+    )
+    u_xr = xr.DataArray(u3, dims=["level", "lat", "lon"])
+    v_xr = xr.DataArray(v3, dims=["level", "lat", "lon"])
+
+    public = srh_package.calculate_storm_relative_helicity(
+        h_xr, u_xr, v_xr, depth=1000.0, storm_u=7.0, storm_v=7.0
+    )
+    assert all(isinstance(r, xr.DataArray) for r in public)
+    assert public[0].dims == ("lat", "lon")
+    for i, arr in enumerate(grid):
+        assert_allclose(public[i].values, arr, rtol=1e-12, atol=1e-12)
+
+
+def test_srh_bottom_offset():
+    """A non-zero bottom changes the integration layer."""
+    height, u, v = _sample_profile()
+    surface = srh_package.calculate_storm_relative_helicity(
+        height, u, v, depth=1000.0, storm_u=7.0, storm_v=7.0
+    )
+    elevated = srh_package.calculate_storm_relative_helicity(
+        height, u, v, depth=1000.0, bottom=200.0, storm_u=7.0, storm_v=7.0
+    )
+    assert elevated[0] != surface[0]
+
+
+def test_srh_nan_handling():
+    height, u, v = _sample_profile()
+    h2 = height.copy()
+    u2 = u.copy()
+    v2 = v.copy()
+    h2[2] = np.nan
+    u2[2] = np.nan
+    v2[2] = np.nan
+    result = srh_package.calculate_storm_relative_helicity(
+        h2, u2, v2, depth=1000.0, storm_u=7.0, storm_v=7.0
+    )
+    assert all(np.isfinite(r) for r in result)
+
+
+def test_srh_input_validation():
+    with pytest.raises(ValueError, match="height must be 1D or 3D"):
+        srh_package.calculate_storm_relative_helicity(
+            np.ones((2, 2), dtype=float),
+            np.ones((2, 2), dtype=float),
+            np.ones((2, 2), dtype=float),
+            depth=1000.0,
+        )
+
+    with pytest.raises(ValueError, match="height must be 1D"):
+        srh_core.srh_profile(
+            np.ones((2, 2), dtype=float),
+            np.ones((2, 2), dtype=float),
+            np.ones((2, 2), dtype=float),
+            1000.0,
+        )


### PR DESCRIPTION
…C backends

Implement multi-dimensional (1D profile -> scalars, 3D grid -> 2D fields) versions of three metpy 1D-only diagnostics, following the existing DCAPE module pattern (Fortran kernel + bind(C) + CPython extension + Python dispatch layer with xarray metadata preservation):

- skyborn.calc.cape: surface-based and most-unstable CAPE/CIN, parcel profiles, and the most-unstable parcel (Bolton theta-e search). Bolton LCL + fixed-step RK4 moist adiabat; metpy-compatible LFC/EL intersection handling and CIN sign convention (<= 0).
- skyborn.calc.srh: storm-relative helicity with AGL conversion, layer subsampling with boundary interpolation (NaN semantics matching metpy's interpolate_1d), and positive/negative/total split.

Validation against metpy 1.7.1 reference soundings: CAPE within +1.1% (Bolton LCL + RK4 vs Romps LCL + LSODA, expected physical-approximation difference), SRH bit-for-bit identical. 27 tests pass. Grid throughput ~10k (CAPE) / ~2M (SRH) profiles per second, 195x/5258x faster than metpy's per-profile loops.